### PR TITLE
Add PR template for contributions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,14 +1,23 @@
 **Describe the contribution**
+
 A clear and concise description of what the contribution brings.
 
 
 **Input given at the prompt**
+
 What you entered.
 
 
 **Response that was received**
+
 What you received in response to your input.
 
 
 **Response that is now received instead**
+
 What you receive with your contribution.
+
+
+**Did you test your contribution with `lab generate` and ensure that it does not produce any warnings or errors?**
+
+Yes or No


### PR DESCRIPTION
This adds a PR template to this repository, prompting the user for input and response received before and after contribution.

Note that support for PR templates isn't up to part with that for issue templates and we can practically only have one PR template. So, the template is targeted at contributors to the taxonomy. For other types of PRs one will have to delete the prefilled text from the description.
