### PR TITLE
Clarify PR template instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,8 @@
-**Describe the contribution**
+If your PR is related to a contribution to the taxonomy, please, fill
+out the following questionaire. If not, replace this whole text and the
+following questionaire with whatever information is applicable to your PR.
+
+**Describe the contribution to the taxonomy**
 
 A clear and concise description of what the contribution brings.
 
@@ -18,6 +22,6 @@ What you received in response to your input.
 What you receive with your contribution.
 
 
-**Did you test your contribution with `lab generate` and ensure that it does not produce any warnings or errors?**
+**Please, confirm that you have tested your contribution with `lab generate` and ensured that it does not produce any warnings or errors:**
 
 Yes or No


### PR DESCRIPTION
We evidently have people unfamiliar with github. This change clarifies that:
* If the template PR description is not applicable it should be replaced by whatever else is appropriate.
* The test with `lab generate` really is expected to be done. Some people seem to think this is optional and it is ok to say "no, I didn't check". :-/
