### PR TITLE
CONTRIBUTING: Add legal section and explain DCO signoff

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,26 @@ Once you've [created a pull request](#how-can-i-contribute), maintainers will re
 - Ensure your contribution is in the proper format (`lab generate` shouldn't report any warnings or errors)
 - Break large changes into a logical series of smaller patches, which are easy to understand individually and combine to solve a broader issue
 
+#### Legal
+
+We have tried to make it as easy as possible to make contributions.
+This applies to how we handle the legal aspects of contribution.
+We use the same approach - the [Developer's Certificate of Origin 1.1 (DCO)][DCO] - that [the Linux Kernel community uses][Linux-DCO] to manage code contributions.
+For this project, unless the file says otherwise, the relevant open source license is [the Apache License, Version 2.0](LICENSE).
+We simply ask that when submitting a patch for review, the developer must include a sign-off statement in the commit message.
+
+Here is an example `Signed-off-by` line, which indicates that the submitter accepts the DCO:
+
+```
+Signed-off-by: John Doe <john.doe@example.com>
+```
+
+You can include this automatically when you commit a change to your local git repository using the following command:
+
+```shell
+git commit -s
+```
+
 ### Reporting Bugs
 
 This section guides you through submitting a bug report. Following these guidelines helps maintainers and the community understand your report ✏️, reproduce the behavior 💻, and find related reports 🔎.
@@ -80,3 +100,6 @@ Improvements to existing functionality are tracked as [GitHub issues using the U
 ## Development
 
 Please consult the [CLI documentation](https://github.com/instruct-lab/cli) to set up your environment.
+
+[DCO]: https://developercertificate.org/
+[Linux-DCO]: https://docs.kernel.org/process/submitting-patches.html#sign-your-work-the-developer-s-certificate-of-origin


### PR DESCRIPTION
[The community repository][1] currently covers the DCO and `Signed-off-by` in the community repository, and this taxonomy repository links that file with:

```Markdown
Please read the [community contribution guide](https://github.com/instruct-lab/community/blob/main/CONTRIBUTING.md) first for general practices for the InstructLab community.
```

But a link floating with the 'main' branch like that is not very reliable, and in a future world where the organization moves to a DCO 1.2 or similar, it would be hard to determine which version a contributor was signing in their commit.  By including the name and version of the DCO locally in this repository, that ambiguity is removed; the contributor was signing the version mentioned in this repository when they made their commit.

I'd prefer to have inlined the complete DCO text in this repository, instead of linking out to https://developercertificate.org/ .  But the licensing of the DCO itself is more restrictive than Apache-2:

> Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
>
> Everyone is permitted to copy and distribute verbatim copies of this license document, but changing it is not allowed.

so I'm following the example set by [the community repo][1] and linking out to external text.

[The community repo][1] also chooses some external links I don't understand for both the DCO text and the fact that the Linux community uses it, and I'm replacing those with what I consider more canonical links.

I'm also linking `LICENSE` and mentioning Apache-2 to make the meaning of DCO (b)'s "appropriate open source license" more explicit than just "we happened to have the Apache-2 text in `LICENSE`".

[1]: https://github.com/instruct-lab/community/blob/b64fc4052c0eee427efc051bd73f06e85b1b319b/CONTRIBUTING.md#legal