### PR TITLE
Add config.yaml to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,7 @@ dmypy.json
 .pyre/
 
 scratch.ipynb
+
+
+# Ignore config.yaml from the cli
+config.yaml


### PR DESCRIPTION
The lab cli uses git to find modified files, adding config.yaml to .gitignore prevents it from being found as a locally modified file and attempting to be parsed as taxonomy.

Fixes https://github.com/instruct-lab/cli/issues/321