### PR TITLE
add fighting games inputs skill

### DIFF
--- a/compositional_skills/writing/freeform/gaming/fighting_games/qna.yaml
+++ b/compositional_skills/writing/freeform/gaming/fighting_games/qna.yaml
@@ -1,0 +1,17 @@
+created_by: ktzee
+seed_examples:
+  - answer: "In Street Fighter 5, the input for the Hadouken is:
+    **Down**, **Down-Forward**, **Forward**, **Punch**.
+    You can use any punch button (light, medium, or heavy) for variations."
+    question: "How do I do a Hadouken in Street Fighter 5?"
+
+  - answer: "The Shoryuken input in Street Fighter 5 is:
+    **Forward**, **Down**, **Down-Forward**, **Punch**.
+    Light, medium, or heavy punch determines the strength of the attack."
+    question: "How do I perform a Shoryuken?"
+
+  - answer: "The Tatsumaki Senpuukyaku (Hurricane Kick) input in Street Fighter 5 is:
+    **Quarter-Circle Back**, **Kick**.
+    Use any kick button (light, medium, heavy) for different versions."
+    question: "How do I do the Hurricane Kick in Street Fighter 5?"
+task_description: "Provide guidance on inputs to execute for special moves in fighting games"


### PR DESCRIPTION
**Describe the contribution to the taxonomy**
Add skill to teach the inputs for popular fighting games

**Input given at the prompt**
what is the input for hadouken in the street fighter 5 game?

**Response that was received**
In Street Fighter 5, the Hadouken move is executed using the following input combination:

Press and hold down the "Shoot" button (usually "medium punch" or "light kick" on your controller or keyboard) while holding the directional pad downward (towards the direction you want to throw the fireball).
Release the "Shoot" button to launch the Hadouken.
Please note that the "Shoot" button and directional pad settings can be customized in the game's options menu, so you may need to adjust the controls to match your preferred configuration. Additionally, the timing and execution of the move can vary depending on the character you're using, so practice and familiarity with your character's specific moveset will help improve your performance when executing the Hadouken in Street Fighter 5.

**Response that is now received instead**
In Street Fighter 5, the input for the Hadouken is:
    **Down**, **Down-Forward**, **Forward**, **Punch**.
    You can use any punch button (light, medium, or heavy) for variations.

**Please, confirm that you have tested your contribution with lab generate and ensured that it does not produce any warnings or errors:**
It seems to generate fine.
