### PR TITLE
Add skill to generate patter songs

### DIFF
--- a/compositional_skills/writing/freeform/poetry/patter/qna.yaml
+++ b/compositional_skills/writing/freeform/poetry/patter/qna.yaml
@@ -1,0 +1,190 @@
+created_by: jlsherrill
+seed_examples:
+- answer: "
+  I am the very model of a modern Major-General
+  I've information vegetable, animal, and mineral
+  I know the kings of England, and I quote the fights historical
+  From Marathon to Waterloo, in order categorical
+  I'm very well acquainted, too, with matters mathematical
+  I understand equations, both the simple and quadratical
+  About binomial theorem I am teeming with a lot o' news
+  With many cheerful facts about the square of the hypotenuse
+
+  With many cheerful facts about the square of the hypotenuse!
+  With many cheerful facts about the square of the hypotenuse!
+  With many cheerful facts about the square of the hypoten-potenuse!
+
+  I'm very good at integral and differential calculus
+  I know the scientific names of beings animalculous
+  In short, in matters vegetable, animal, and mineral
+  I am the very model of a modern Major-General
+
+
+  In short, in matters vegetable, animal, and mineral
+  He is the very model of a modern Major-General!
+
+  I know our mythic history, King Arthur's and Sir Caradoc's
+  I answer hard acrostics, I've a pretty taste for paradox
+  I quote in elegiacs all the crimes of Heliogabalus
+  In conics I can floor peculiarities parabolous
+  I can tell undoubted Raphaels from Gerard Dows and Zoffanies
+  I know the croaking chorus from The Frogs of Aristophanes!
+  Then I can hum a fugue of which I've heard the music's din afore
+  And whistle all the airs from that infernal nonsense Pinafore
+
+  And whistle all the airs from that infernal nonsense Pinafore!
+  And whistle all the airs from that infernal nonsense Pinafore!
+  And whistle all the airs from that infernal nonsense Pina-Pinafore!
+
+  Then I can write a washing bill in Babylonic cuneiform
+  And tell you ev'ry detail of Caractacus's uniform
+  In short, in matters vegetable, animal, and mineral
+  I am the very model of a modern Major-General
+
+  In short, in matters vegetable, animal, and mineral
+  He is the very model of a modern Major-General!
+
+  In fact, when I know what is meant by 'mamelon' and 'ravelin'
+  When I can tell at sight a Mauser rifle from a Javelin
+  When such affairs as sorties and surprises I'm more wary at
+  And when I know precisely what is meant by 'commissariat'
+  When I have learnt what progress has been made in modern gunnery
+  When I know more of tactics than a novice in a nunnery
+  In short, when I've a smattering of elemental strategy
+  You'll say a better Major-General has never sat a gee
+
+  You'll say a better Major-General has never sat a gee!
+  You'll say a better Major-General has never sat a gee!
+  You'll say a better Major-General has never sat a, sat a gee!
+
+
+  For my military knowledge, though I'm plucky and adventury
+  Has only been brought down to the beginning of the century
+  But still, in matters vegetable, animal, and mineral
+  I am the very model of a modern Major-General
+
+  But still, in matters vegetable, animal, and mineral
+  He is the very model of a modern Major-General!"
+  question: Write a patter song about a military general
+- answer: "
+  When you're lying awake
+  With a dismal headache
+  And repose is taboo'd by anxiety
+  I conceive you may use
+  Any language you choose
+  To indulge in, without impropriety;
+  For your brain is on fire
+  The bedclothes conspire
+  Of usual slumber to plunder you:
+  First your counterpane goes
+  And uncovers your toes
+  And your sheet slips demurely from under you;
+
+  Then the blanketing tickles
+  You feel like mixed pickles
+  So terribly sharp is the pricking
+  And you're hot, and you're cross
+  And you tumble and toss
+  Till there's nothing ‘twixt you and the ticking
+  Then the bedclothes all creep
+  To the ground in a heap
+  And you pick 'em all up in a tangle;
+  Next your pillow resigns
+  And politely declines
+  To remain at its usual angle!
+
+  Well, you get some repose
+  In the form of a doze
+  With hot eyeballs and head ever aching
+  But your slumbering teems
+  With such horrible dreams
+  That you'd very much better be waking;
+  For you dream you are crossing
+  The Channel, and tossing
+  About in a steamer from Harwich
+  Which is something between
+  A large bathing machine
+  And a very small second-class carriage
+
+  And you're giving a treat
+  (Penny ice and cold meat)
+  To a party of friends and relations
+  They're a ravenous horde
+  And they all came on board
+  At Sloane Square and South Kensington Stations
+  And bound on that journey
+  You find your attorney
+  (Who started that morning from Devon);
+  He's a bit undersized
+  And you don't feel surprised
+  When he tells you he's only eleven
+
+  Well, you're driving like mad
+  With this singular lad
+  (By the by, the ship's now a four-wheeler)
+  And you're playing round games
+  And he calls you bad names
+  When you tell him that 'ties pay the dealer';
+  But this you can't stand
+  So you throw up your hand
+  And you find you're as cold as an icicle
+  In your shirt and your socks
+  (The black silk with gold clocks)
+  Crossing Salisbury Plain on a bicycle:
+
+  And he and the crew
+  Are on bicycles too
+  Which they've somehow or other invested in
+  And he's telling the tars
+  All the particulars
+  Of a company he's interested in
+  It's a scheme of devices
+  To get at low prices
+  All goods from cough mixtures to cables
+  (Which tickled the sailors)
+  By treating retailers
+  As though they were all vegetables
+
+  You get a good spadesman
+  To plant a small tradesman
+  (First take off his boots with a boot-tree)
+  And his legs will take root
+  And his fingers will shoot
+  And they'll blossom and bud like a fruit-tree
+  From the greengrocer tree
+  You get grapes and green pea
+  Cauliflower, pineapple, and cranberries
+  While the pastry-cook plant
+  Cherry brandy will grant
+  Apple puffs, and three corners, and Banburys
+
+  The shares are a penny
+  And ever so many
+  Are taken by Rothschild and Baring
+  And just as a few
+  Are allotted to you
+  You awake with a shudder despairing
+
+  You're a regular wreck
+  With a crick in your neck
+  And no wonder you snore
+  For your head's on the floor
+  And you've needles and pins
+  From your soles to your shins
+  And your flesh is a-creep
+  For your left leg's asleep
+  And you've cramp in your toes
+  And a fly on your nose
+  And some fluff in your lung
+  And a feverish tongue
+  And a thirst that's intense
+  And a general sense
+  That you haven't been sleeping in clover;
+  But the darkness has passed
+  And it's daylight at last
+  And the night has been long
+  Ditto, ditto my song
+  And thank goodness they're both of them over!"
+  question: Write a patter song about trying to fall asleep in bed
+task_description: "This task should construct a patter song, that is characterized by a fast tempo with a rapid
+                   succession of rhythmic patterns in which each syllable of text corresponds to one note"


### PR DESCRIPTION


**Describe the contribution to the taxonomy**

Adds  a skill to generate a patter song.  A patter song is characterized by a fast tempo with a rapid succession of rhythmic patterns in which each syllable of text corresponds to one note

**Input given at the prompt**

Write a patter song about frogs


**Response that was received**
```
Here's a little ditty about our amphibian friends, the frogs:              
                                                                           
In the vernal pool, where life begins,                                     
A chorus of croaks, as the sun begins to wane,                             
Tiny tadpoles, in their watery domain,                                     
A symphony of life, in the soft, damp rain.                                
                                                                           
Green, brown, and speckled, they blend with the grass,                     
Camouflaged, yet making a raucous, bold pass,                              
From the lily pads, they leap with a splash,                               
In their unique world, they make their own flash.                          
                                                                           
Frogs, the musicians, with voices so bright,                               
Serenading the night, in the soft moonlight,                               
A dance of life, in the cool, gentle night,                                
Frogs, the poets, in the quiet, starry night.                              
```

**Response that is now received instead**

Wasn't able to test with this change, but hopefully with these changes, the output would fix a patter song better.


**Please, confirm that you have tested your contribution with `lab generate` and ensured that it does not produce any warnings or errors:**

No, but i will continue to try to get it to complete.
