### PR TITLE
Add skill to generate ChangeLog entries from patches

### DIFF
--- a/compositional_skills/writing/grounded/summarization/code/changelog/qna.yaml
+++ b/compositional_skills/writing/grounded/summarization/code/changelog/qna.yaml
@@ -1,0 +1,16 @@
+created_by: davidmalcolm
+seed_examples:
+- answer: "gcc/rust/ChangeLog:\n\t* typecheck/rust-hir-trait-reference.cc (TraitItemReference::is_optional): Remove\n\tstray semicolon.\n"
+  question: "Generate a ChangeLog entry for the following patch\ndiff --git a/gcc/rust/typecheck/rust-hir-trait-reference.cc b/gcc/rust/typecheck/rust-hir-trait-reference.cc\nindex 499999429fde..6afb6f4df6d1 100644\n--- a/gcc/rust/typecheck/rust-hir-trait-reference.cc\n+++ b/gcc/rust/typecheck/rust-hir-trait-reference.cc\n@@ -37,7 +37,7 @@ bool\n TraitItemReference::is_optional () const\n {\n   return optional_flag;\n-};\n+}\n \n std::string\n TraitItemReference::get_identifier () const\n"
+  # based on GCC commit b8934ebd88b50c6aae304eede565f94cb860a3c2
+  # https://github.com/gcc-mirror/gcc/commit/b8934ebd88b50c6aae304eede565f94cb860a3c2
+  # Note the use of tab characters in the output.
+
+- answer: "gcc/ChangeLog:\t* Makefile.in: Add $(ZLIBINC) to CFLAGS-analyzer/engine.o.\n"
+  question: "Make me a ChangeLog entry for this patch:\ndiff --git a/gcc/Makefile.in b/gcc/Makefile.in\nindex c710bad27b17..9c6c1c93b976 100644\n--- a/gcc/Makefile.in\n+++ b/gcc/Makefile.in\n@@ -2296,6 +2296,7 @@ s-bversion: BASE-VER\n \n CFLAGS-toplev.o += -DTARGET_NAME=\\\"$(target_noncanonical)\\\"\n CFLAGS-optinfo-emit-json.o += -DTARGET_NAME=\\\"$(target_noncanonical)\\\" $(ZLIBINC)\n+CFLAGS-analyzer/engine.o += $(ZLIBINC)\n \n pass-instances.def: $(srcdir)/passes.def $(PASSES_EXTRA) \\n \t\t    $(srcdir)/gen-pass-instances.awk\n"
+  # based on GCC commit commit c1c2ccc74cb6f547118431d8142bc894991b104a
+  # https://github.com/gcc-mirror/gcc/commit/c1c2ccc74cb6f547118431d8142bc894991b104a
+  # Note the mixture of spaces and tabs in the input.
+
+task_description: 'Generate formatted ChangeLog entries from patches'
+# See e.g. https://www.gnu.org/prep/standards/html_node/Style-of-Change-Logs.html


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionaire. If not, replace this whole text and the
following questionaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

Generate GNU-format ChangeLogs from raw patches.

Some notes:
- I'd have preferred to do this as one prompt ("generate me a ChangeLog for this patch") with multiple context/answer pairs, but am unsure of the syntax for expressing this
- I've never used YAML, and ended up having to hand-escape the multiline strings (which contain mixtures of spaces and tabs).  Should this be a YAML string containing a markdown string expressing that these are code fragments? (since these contain significant whitespace, in specific file formats)

**Input given at the prompt**
```

>>> Generate a ChangeLog entry for the following patch                                                                                  [M][default]
    diff --git a/gcc/rust/typecheck/rust-hir-trait-reference.cc b/gcc/rust/typecheck/rust-hir-trait-reference.cc
    index 499999429fde..6afb6f4df6d1 100644
    --- a/gcc/rust/typecheck/rust-hir-trait-reference.cc
    +++ b/gcc/rust/typecheck/rust-hir-trait-reference.cc
    @@ -37,7 +37,7 @@ bool
     TraitItemReference::is_optional () const
     {
       return optional_flag;
    -};
    +}
 
     std::string
     TraitItemReference::get_identifier () const

```

**Response that was received**
```

╭───────────────────────────────────────────────────────── ggml-merlinite-7b-0302-Q4_K_M ──────────────────────────────────────────────────────────╮
│ The commit message for this change would be:                                                                                                     │
│                                                                                                                                                  │
│ Updated Rust trait reference type checking to handle optional trait references correctly.                                                        │
│                                                                                                                                                  │
│ This commit updates the Rust trait reference type checking to accurately handle optional trait references, ensuring that the compiler produces   │
│ correct error messages when encountering invalid trait references. The changes made in this commit include updating the `is_optional()` method   │
│ to properly determine if a trait reference is optional, and updating the `get_identifier()` method to retrieve the identifier of the trait       │
│ reference, taking into account optional trait references. These updates ensure that the compiler can accurately determine if a trait reference   │
│ is optional and provide appropriate error messages when necessary.                                                                               │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 31.173 seconds ─╯

```
which is completely bogus: not a ChangeLog entry, and misidentifies the point of the change.

My hand-written ChangeLog for that commit can be seen at https://github.com/gcc-mirror/gcc/commit/b8934ebd88b50c6aae304eede565f94cb860a3c2

**Response that is now received instead**

Not tested.


**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

Unable to run `lab generate`, not tested.

The `qna.yaml` file was [linted](https://yamllint.com)
