### PR TITLE
Add synthetic data generated by cli to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,7 @@ scratch.ipynb
 
 # Ignore config.yaml from the cli
 config.yaml
+
+# Ignore files created by lab generate
+*ggml*.json*
+


### PR DESCRIPTION
 Signed-off-by: Chris Jones <chjones@redhat.com>

I'm pretty sure the files created by `lab generate` (a mix of `.json` and `.jsonl`) are not intended to ever be committed, so I added them to `.gitignore`.