### PR TITLE
ci: Only run yamllint on changes to qna.yaml files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,14 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main 
+      - main
+    paths:
+      - 'compositional_skills/**/qna.yaml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'compositional_skills/**/qna.yaml'
 
 jobs:
   lint:


### PR DESCRIPTION
Saving Github actions quota and reducing overhead for doc changes
