### PR TITLE
Adding skill for telling jokes that start with the popular "<someone> walks into a bar..." setting

### DIFF
--- a/compositional_skills/writing/freeform/jokes/walk-into-a-bar/qna.yaml
+++ b/compositional_skills/writing/freeform/jokes/walk-into-a-bar/qna.yaml
@@ -1,0 +1,44 @@
+task_description: >
+  The walk-into-a-bar task enables the telling of jokes that
+  start with the following setting: "A guy walks into a bar..."  or a similar
+  expression, mentioning someone or something walking into a bar or a pub.
+created_by: fabiobrz
+seed_examples:
+  - question: Tell me a walk-into-a-bar joke about aircrafts.
+    answer: >
+      A guy walks into a bar. He asks the bartender, "Do you have any
+      helicopter flavored potato chips?"
+
+      The bartender shakes his head and says, "No, we only have plain"
+    attribution:
+      - source: 'https://barsandbartending.com/walks-into-a-bar-jokes/'
+        license: CC-PDDC
+  - question: Tell me a walk-into-a-bar joke about Physics.
+    answer: |
+      Two hydrogen atoms walk into a bar. One says, "I’ve lost my electron."
+      The other says, "Are you sure?"
+      The first replies, "Yes, I’m positive"
+    attribution:
+      - source: 'https://barsandbartending.com/walks-into-a-bar-jokes/'
+        license: CC-PDDC
+  - question: Tell me a walk-into-a-bar joke about Romans.
+    answer: |
+      A Roman walks into a bar, sticks two fingers up to the barman and says,
+      "Five beers please."
+    attribution:
+      - source: 'http://www.funny2.com/bar.htm'
+        license: CC-PDDC
+  - question: Tell me a walk-into-a-bar joke about horses.
+    answer: |
+      A man walks into a bar owned by horses. The bartender says,
+      "Why the short face?"
+    attribution:
+      - source: 'http://www.funny2.com/bar.htm'
+        license: CC-PDDC
+  - question: Tell me a walk-into-a-bar joke about skeletons.
+    answer: |
+      A skeleton walks into a bar and says, "Gimme a beer, and a mop."
+    attribution:
+      - source: 'http://www.funny2.com/bar.htm'
+        license: CC-PDDC
+


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

- Adding skill for telling jokes that start with the popular "<someone> walks into a bar..." setting.


**Input given at the prompt**

```
Tell me a walk-into-a-bar joke about aircrafts.
```


**Response that was received**

```
Sure, here's a light-hearted joke for you:

Why did the Roman walk into a bar?

To get to the other side!

This joke plays on the fact that Romans built infrastructure, such as roads and bridges, to facilitate travel and 
communication. The "other side" in this case could refer to the other side of the road or bar, implying that the 
Roman's primary goal was to cross the bar's threshold, not to consume alcohol.
```

**Response that is now received instead**

```
A Roman walks into a bar, and the bartender asks, "What's the matter? You don't look so well." The Roman 
replies, "I think I've caught the 'Roman fever,' it's making me feel 'gladiator' unwell." The bartender responds, "I 
see, you must be looking for a 'ceaser' to your problems." The Roman laughs and orders a "martini" to help him 
"numb" the pain.
5. Explanation:
This joke plays on the words "fever" and "gladiator," which have similar sounds but different meanings. It also 
involves wordplay with the name "Caesar," which is the English term for a Roman emperor. The joke is meant to 
be lighthearted and entertaining, rather than offensive or harmful. It's important to note that this joke may not 
be appropriate in all contexts, as humor can be subjective and depend on the audience. However, in a casual, 
friendly conversation, this joke could be a fun way to break the ice or lighten the mood.
6. Alternative Version:
A Roman walks into a bar, and the b
```

**Additional context**

**IMPORTANT**: using `CC-PDDC` since those one-liners are from public domain web sites, and the ownership isn't clear. Feel free to push back in case this not acceptable, but also to provide a way for allowing this use case.

> **The following section is now outdated, since I updated the PR after review, and done another training iteration**
Actually the answer I got from the last trained model was a bit weird. It starts as I reported above, then it goes into a " Or is that <SOMETHING>? I can't tell, it's all a blur. And if it's not a blur, then it's just a ..." series.
I have gone through several iterations of the experiment, but overall I am not satisfied with my own outcome. I thought I could teach the model to say proper bar jokes with my _skill_ contribution, specifically I expected the model to understand that this kind of joke should start with a setting that mentions someone or even something entering a bar, or a pub, like "A man walks into a bar...", or something like that.
I've gotten close to the desired result in some iterations, but I don't feel I've reached a consistent outcome.
I'll now leave this contribution to the maintainers to evaluate.
Anyway, I've got a nice transcription of the chat sessions I've run with the original model and the trained one, so feel free to ask for more details.



**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
