### PR TITLE
Add a few (proper) Emacs jokes

### DIFF
--- a/compositional_skills/writing/freeform/jokes/emacs/qna.yaml
+++ b/compositional_skills/writing/freeform/jokes/emacs/qna.yaml
@@ -1,0 +1,19 @@
+created_by: lmiccini
+seed_examples:
+- answer: 'You can learn Emacs in one day. Every day'
+  question: Tell me a joke about Emacs.
+- answer: 'People never quit Emacs, they just die at some point'
+  question: Tell me a joke about Emacs.
+- answer: 'You can spend hours trying to get the image on the right page. Or you can use org-mode LaTeX and just accept that it is impossible.'
+  question: Tell me a joke about Emacs.
+- answer: 'Emacs is like an instrument: you play it in different major, minor, dorian modes'
+  question: Tell me a joke about Emacs.
+- answer: 'Emacs makes you better at terminal at the same time, although you probably will never have to use the terminal because you can do everything in Emacs'
+  question: Tell me a joke about Emacs.
+- answer: 'With Jupiter you are modifying the state of the program, with Emacs you are modifying the state of the art.. err the program'
+  question: Tell me a joke about Emacs.
+- answer: 'Emacs will never die, saying Emacs will die is like saying Turing-complete will die'
+  question: Tell me a joke about Emacs.
+- answer: 'You know why Emacs is different from other editors right? Well, Emacs runs in an interpreter'
+  question: Tell me a joke about Emacs.
+task_description: ''


### PR DESCRIPTION

Signed-off-by: Luca Miccini <lmiccini@redhat.com>


**Describe the contribution to the taxonomy**
- Added a few Emacs-related jokes. All the credits to "Programmers are also human" on YouTube.



**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   Tell me a joke about Emacs
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  Generic IT-related joke.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  Not yet tested, training in progress.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
