### PR TITLE
Add a skill to write formal out of office email

### DIFF
--- a/compositional_skills/writing/freeform/prose/emails/formal/qna.yaml
+++ b/compositional_skills/writing/freeform/prose/emails/formal/qna.yaml
@@ -40,4 +40,20 @@ seed_examples:
     [Your Contact Information]'
   question: Could you help me write a formal email to inquire about the progress of
     my internship application?
+- answer: 'Subject: Out of office from [Tentative Date] to [Tentative Date]
+
+    Dear [Recipient''s Name],
+
+    Thanks for reaching out. I am away from office starting from [Tentative Date]
+    to [Tentative Date], both days inclusive and I am not available on email.
+    You may reach out to my manager [Manager Name] during this period if you
+    need anything in general. For [specific project or task] that I am involved
+    with, you may reach out to [Co-worker Name]. I will try to respond to the
+    backlog emails once I am back but in case I miss or forget, please do not
+    hesitate to resend your email again at that time.
+    Thanks for your underastanding.
+
+    Sincerely,
+    [Your Full Name]'
+  question: Could you help me write an out of office formal email?
 task_description: ''


### PR DESCRIPTION
Add a qna to teach the model how a formal out of office email might look like.

I was not able to train the new skill as my Mac crashed while running `lab train`.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ x] tested contribution with `lab generate`
- [ x] `lab generate` does not produce any warnings or errors
- [ x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x ] the `qna.yaml` file was [linted](https://yamllint.com)
