### PR TITLE
Create a Linux development skill to determine userspace memory page size

### DIFF
--- a/compositional_skills/extraction/information/development/linux/page_size/qna.yaml
+++ b/compositional_skills/extraction/information/development/linux/page_size/qna.yaml
@@ -1,0 +1,81 @@
+# The intent of this skill is to teach the ability to determine the size
+# of a userspace page of memory. That size can be distinct from the size
+# of a kernel page of memory (which can be dynamic with transparent huge
+# pages). We use three questions and answers to arrive at the same answer,
+# but the intent is to teach a skill since the answer is going to be
+# different depending on what the results give on the system. The goal is
+# for a developer to give the model some context information and the model
+# can give the answer by performing the skill in any variety of contexts.
+# The three questions and answers are distinct in that one is entirely
+# using the proc filesystem, one uses a CLI tool, and the other is the
+# output of the dynamic loader's diagnostics information (which has all
+# of the auxiliary vector data from the Linux kernel).
+#
+# The skill is context dependent and applies to determining the normative
+# size of a userspace page of memory on Linux.
+---
+created_by: codonell
+seed_examples:
+  - answer: 'The size of a page is 4096 bytes of 0x1000 in hex.'
+    context: "$ cat /proc/self/smaps | grep KernelPageSize | head -1\n\
+      \ KernelPageSize:        4 kB\n"
+    question: |
+      Extract the size of a userspace page of memory from the kernel shared
+      mappings output.
+  - answer: 'The size of a page is 4096 bytes or 0x1000 in hex.'
+    context: "$ /usr/bin/getconf PAGE_SIZE\n\
+      \ 4096\n"
+    question: |
+      Extract the size of a userspace page of memory from the system getconf
+      output.
+  - answer: 'The size of a page is 4096 bytes or 0x1000 in hex.'
+    context: "$ ld.so --list-diagnostics | grep auxv\n\
+      \ auxv[0x0].a_type=0x21\n\
+      \ auxv[0x0].a_val=0x7ffe01b23000\n\
+      \ auxv[0x1].a_type=0x33\n\
+      \ auxv[0x1].a_val=0x6f0\n\
+      \ auxv[0x2].a_type=0x10\n\
+      \ auxv[0x2].a_val=0xbfebfbff\n\
+      \ auxv[0x3].a_type=0x6\n\
+      \ auxv[0x3].a_val=0x1000\n\
+      \ auxv[0x4].a_type=0x11\n\
+      \ auxv[0x4].a_val=0x64\n\
+      \ auxv[0x5].a_type=0x3\n\
+      \ auxv[0x5].a_val=0x7f135b4f5040\n\
+      \ auxv[0x6].a_type=0x4\n\
+      \ auxv[0x6].a_val=0x38\n\
+      \ auxv[0x7].a_type=0x5\n\
+      \ auxv[0x7].a_val=0xb\n\
+      \ auxv[0x8].a_type=0x7\n\
+      \ auxv[0x8].a_val=0x0\n\
+      \ auxv[0x9].a_type=0x8\n\
+      \ auxv[0x9].a_val=0x0\n\
+      \ auxv[0xa].a_type=0x9\n\
+      \ auxv[0xa].a_val=0x7f135b510bc0\n\
+      \ auxv[0xb].a_type=0xb\n\
+      \ auxv[0xb].a_val=0x3e8\n\
+      \ auxv[0xc].a_type=0xc\n\
+      \ auxv[0xc].a_val=0x3e8\n\
+      \ auxv[0xd].a_type=0xd\n\
+      \ auxv[0xd].a_val=0x3e8\n\
+      \ auxv[0xe].a_type=0xe\n\
+      \ auxv[0xe].a_val=0x3e8\n\
+      \ auxv[0xf].a_type=0x17\n\
+      \ auxv[0xf].a_val=0x0\n\
+      \ auxv[0x10].a_type=0x19\n\
+      \ auxv[0x10].a_val=0x7ffe01a1d249\n\
+      \ auxv[0x11].a_type=0x1a\n\
+      \ auxv[0x11].a_val=0x2\n\
+      \ auxv[0x12].a_type=0x1f\n\
+      \ auxv[0x12].a_val=\"/usr/bin/ld.so\"\n\
+      \ auxv[0x13].a_type=0xf\n\
+      \ auxv[0x13].a_val=\"x86_64\"\n\
+      \ auxv[0x14].a_type=0x1b\n\
+      \ auxv[0x14].a_val=0x1c\n\
+      \ auxv[0x15].a_type=0x1c\n\
+      \ auxv[0x15].a_val=0x20\n"
+    question: |
+      Extract the size of a userspace page of memory from the dynamic loader
+      diagnostics output.
+task_description: |
+  Extract the size of a userspace page of memory from the Linux kernel


### PR DESCRIPTION
* Extract Linux userspace memory page size from a given context.

Explains the skill of extracting a userspace memory page size from a given context.

The existing answers from the model are somewhat poor for the dynamic loader auxiliary vector diagnostic information. The best answer is had when extracting from getconf output, but the skill provides 3 ways to perform the task (proc, cli, ld.so) to try to link the other two better answers.

**Describe the contribution to the taxonomy**

- Adds a Linux development skill to determine the userspace memory page size.

The userspace memory page size is important to developers for optimizing placement of data in userspace applications.

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
>>> Extract the userspace memory page size given the context: ...
```
With the context for extraction provided.

**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
╭──────────────────────────────────────────── ggml-merlinite-7b-Q4_K_M ────────────────────────────────────────────╮
│ The Linux kernel page size can be determined from this text using the `/usr/bin/ld.so --list-diagnostics`        │
│ command followed by `grep auxv`. The command displays various auxiliary vector (auxv) entries, one of which is   │
│ for the page size. The `a_type` field of 0x10 corresponds to the page size, and its `a_val` field is 0xbfebfbff, │
│ which is 4096 in decimal, representing 4KiB page size.                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────── elapsed 27.806 seconds ─╯
>
```
The response is wrong in both the type and value, but the answer is correct and we should improve that.

**Response that is now received instead**

Did not run chat with a new model on x86_64 Linux laptop. Only ran ``yamllint`` to verify and ``lab generate`` to ensure generation works.

The answer given by the model is poor in this case and I expect my skill to determine page size will improve the skill.

The answer is better for ``getconf``, but I want to improve the diagnostic extraction so I use ``getconf`` in my Q&A help link together the same concept.

```
╭──────────────────────────────────────────── ggml-merlinite-7b-Q4_K_M ────────────────────────────────────────────╮
│ The `getconf` command is used to retrieve various system configuration details, including the userspace memory   │
│ page size. By executing `getconf PAGE_SIZE`, we can determine the current page size in userspace. In this case,  │
│ the output is 4096, which means the userspace memory page size is 4KiB.                                          │
╰───────────────────────────────────────────────────────────────────────────────────────── elapsed 17.471 seconds ─╯
```
Likewise I include the `procfs` example to similarly link the concept:
```
╭──────────────────────────────────────────── ggml-merlinite-7b-Q4_K_M ────────────────────────────────────────────╮
│ The `/proc/self/smaps` file contains memory mapping information about the current process. By grepping for       │
│ `KernelPageSize` in this file, we can extract the userspace memory page size. The `head -1` command is used to   │
│ retrieve only the first line of output. In this case, the output indicates that the userspace memory page size   │
│ is 4 kB.                                                                                                         │
╰───────────────────────────────────────────────────────────────────────────────────────── elapsed 19.936 seconds ─╯
```
The answer here could be improved to say ``4KiB`` since the kernel means that but doesn't print it.


**Contribution checklist**

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
