### PR TITLE
Add skill to write openQA commands for mouse.

### DIFF
--- a/compositional_skills/programming/openqa/mouse_click/qna.yaml
+++ b/compositional_skills/programming/openqa/mouse_click/qna.yaml
@@ -1,0 +1,11 @@
+created_by: lruzicka
+seed_examples:
+  - answer: mouse_click('left');
+    question: Click the left mouse button.
+  - answer: mouse_click('right');
+    question: Click the right mouse button.
+  - answer: mouse_click('left', O.5);
+    question: Click the left mouse button for 0.5 second.
+  - answer: mouse_click('right', 1);
+    question: Click the right mouse button for 1 second.
+task_description: 'Learn how to click the mouse buttons in openQA.'

--- a/compositional_skills/programming/openqa/mouse_dclick/qna.yaml
+++ b/compositional_skills/programming/openqa/mouse_dclick/qna.yaml
@@ -1,0 +1,11 @@
+created_by: lruzicka
+seed_examples:
+  - answer: mouse_dclick('left');
+    question: Doubleclick the left mouse button.
+  - answer: mouse_dclick('right');
+    question: Doubleclick the right mouse button.
+  - answer: mouse_dclick('left', 0.8);
+    question: Doubleclick the left mouse button for 0.8 second.
+  - answer: mouse_dclick('right', 0.3);
+    question: Doubleclick the right mouse button for 0.3 second.
+task_description: 'Learn how to double click the mouse buttons in openQA.'

--- a/compositional_skills/programming/openqa/mouse_drag/qna.yaml
+++ b/compositional_skills/programming/openqa/mouse_drag/qna.yaml
@@ -1,0 +1,11 @@
+created_by: lruzicka
+seed_examples:
+  - answer: mouse_drag('tag1', 'tag2', 'left');
+    question: Left click and drag the mouse from tag1 to tag2.
+  - answer: mouse_drag('tag1', 'tag2', 'right');
+    question: Right click and drag the mouse from tag1 to tag2.
+  - answer: mouse_drag(150, 100, 280, 200, 'left');
+    question: Left click and drag the mouse from 150, 100 to 280, 200.
+  - answer: mouse_drag(40, 40, 620, 30, 'right');
+    question: Right click and drag the mouse from 40, 40 to 620, 30.
+task_description: 'Learn how to click and drag mouse in openQA.'

--- a/compositional_skills/programming/openqa/mouse_hide/qna.yaml
+++ b/compositional_skills/programming/openqa/mouse_hide/qna.yaml
@@ -1,0 +1,7 @@
+created_by: lruzicka
+seed_examples:
+  - answer: mouse_hide(100);
+    question: Move the mouse outside the visible screen by 100 pixels.
+  - answer: mouse_hide();
+    question: Hide the mouse cursor.
+task_description: 'Learn how to hide the mouse cursor in openQA.'

--- a/compositional_skills/programming/openqa/mouse_set/qna.yaml
+++ b/compositional_skills/programming/openqa/mouse_set/qna.yaml
@@ -1,0 +1,5 @@
+created_by: lruzicka
+seed_examples:
+  - answer: mouse_set(100, 250);
+    question: Move the mouse to 100, 250.
+task_description: 'Learn to set the mouse cursor to given position in openQA.'

--- a/compositional_skills/programming/openqa/mouse_tclick/qna.yaml
+++ b/compositional_skills/programming/openqa/mouse_tclick/qna.yaml
@@ -1,0 +1,11 @@
+created_by: lruzicka
+seed_examples:
+  - answer: mouse_tclick('left');
+    question: Tripleclick the left mouse button.
+  - answer: mouse_tclick('right');
+    question: Tripleclick the right mouse button.
+  - answer: mouse_tclick('left', 0.4);
+    question: Tripleclick the left mouse button for 0.4 second.
+  - answer: mouse_tclick('right', 0.2);
+    question: Tripleclick the right mouse button for 0.2 second.
+task_description: 'Learn how to triple click the mouse buttons in openQA.'


### PR DESCRIPTION
This PR adds several simple skills so that the model will be able to turn simple English commands into
openQA directives for mouse actions.

Example:
Question: Click the left mouse button in openQA.
Answer: mouse_click('left');

**Describe the contribution to the taxonomy**

It should teach the model the following mouse actions using the openQA testapi commands.
- mouse_click
- mouse_set
- mouse_hide
- mouse_drag
- mouse_dclick
- mouse_tclick


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
What command shall I use in the OpenQA test script to click with the left mouse button?                                                                                                                                                 
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
╭────────────────────────────────────────────────────────────────────────────────────────────────────────────── ggml-merlinite-7b-0302-Q4_K_M ───────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ To simulate a left mouse click in an OpenQA test script, you can use the `click` command with the `left` option, followed by the target element's XPath or CSS selector. Here's an example of how to use this command in your test script:                 │
│                                                                                                                                                                                                                                                            │
│ ```json                                                                                                                                                                                                                                                    │
│ {                                                                                                                                                                                                                                                          │
│   "type": "click",                                                                                                                                                                                                                                         │
│   "element": "css=button[type='submit']",                                                                                                                                                                                                                  │
│   "left": true,                                                                                                                                                                                                                                            │
│   "options": { "waitUntil": "notNetworkError" }                                                                                                                                                                                                            │
│ }                                                                                                                                                                                                                                                          │
│ ```                                                                                                                                                                                                                                                        │
│                                                                                                                                                                                                                                                            │
│ In this example, the `click` command will simulate a left mouse click on the element with the CSS selector `button[type='submit']`. The `waitUntil` option ensures that the test waits until the network request related to the clicked element is not in  │
│ error before proceeding to the next step in the test script.                                                                                                                                                                                               │
│                                                                                                                                                                                                                                                            │
│ By using the `left` option, you can simulate a left mouse click, which is the equivalent of clicking the primary button on most modern mouse devices. This command allows you to automate user interactions with the test environment, making it easier to │
│ create comprehensive and reliable test cases for your software.                                                                                                                                                                                            │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 31.104 seconds ─╯

```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
mouse_click('left');
```
plus a bunch of other commands, however I only could test it in the Colab.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [X] tested contribution with `lab generate`
- [X] `lab generate` does not produce any warnings or errors
- [X] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [X] the `qna.yaml` file was [linted](https://yamllint.com)
