### PR TITLE
Add skill for rewriting text without using the letter "e" (lipograms)

### DIFF
--- a/compositional_skills/writing/freeform/prose/avoid_e/qna.yaml
+++ b/compositional_skills/writing/freeform/prose/avoid_e/qna.yaml
@@ -1,0 +1,9 @@
+created_by: josmyers
+seed_examples:
+  - answer: '"Mandating priority AI skills contribution ran into practical limitations."'
+    question: 'Rewrite the following without using the letter "e": "The urgent requirement to contribute AI skills encountered real issues in practice."'
+  - answer: '"AI is notorious for not doing various things soundly."'
+    question: 'Rewrite the following without using the letter "e": "AI is well-known for its weaknesses in certain areas."'
+  - answer: "\"It's common not to think about IP rights in AI training data.\""
+    question: 'Rewrite the following without using the letter "e": "Intellectual property rights in AI training material are often ignored."'
+task_description: 'Rewrite text avoiding the letter "e"'


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- A skill for rewriting text to avoid the letter "e" (lipograms)
- https://en.wikipedia.org/wiki/Lipogram


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
>> Rewrite the following without using the letter "e": "AI has promise but also
 serious issues at present."
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
╭─────────────────────── ggml-merlinite-7b-0302-Q4_K_M ────────────────────────╮
│ "AI holds potential yet also significant challenges presently."              │
╰────────────────────────────────────────────────────── elapsed 1.211 seconds ─╯
```

As you can see, the AI failed to avoid the letter "e". A better response might have been "AI is promising but also has major flaws right now.".

**Response that is now received instead**

Not tested retraining on Red Hat laptop without a GPU.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
