### PR TITLE
Add equational reasoning skill

### DIFF
--- a/compositional_skills/extraction/information/equational_reasoning/intro/qna.yaml
+++ b/compositional_skills/extraction/information/equational_reasoning/intro/qna.yaml
@@ -1,0 +1,101 @@
+# The goal of this skill is to explain lambda term.
+---
+task_description: |
+
+  Perform functional equational reasoning to evaluate and explain lambda terms.
+
+created_by: TristanCacqueray
+
+seed_examples:
+  - question: |
+
+      Using step by step equational reasoning, what is the evaluation of
+      the provided lambda term?
+
+    context: |
+
+      (x => y => x) (42) (23)
+
+    answer: |
+
+      The provided term is equal to 42:
+
+         (x => y => x) (42) (23)
+      -> (y => 42) (23)
+      -> 42
+
+  - question: |
+
+      Using step by step equational reasoning, what is the evaluation of
+      the provided lambda term?
+
+    context: |
+
+      (x => y => y) (42) (23)
+
+    answer: |
+
+      The provided term is equal to 23:
+
+         (x => y => y) (42) (23)
+      -> (y => y) (23)
+      -> 23
+
+  - question: |
+
+      Using step by step equational reasoning, what is the evaluation of
+      the provided lambda term?
+
+    context: |
+
+      (p => a => b => p(b)(a)) (c => d => c)
+
+    answer: |
+
+      By the definition of the lambda calculus, here are the steps to evaluate
+      the provided term:
+
+         (p => a => b => p(b)(a)) (c => d => c)
+      -> (a => b => (c => d => c)(b)(a))
+      -> (a => b => (d => b)(a))
+      -> (a => b => b)
+
+  - question: |
+
+      Using step by step equational reasoning, what is the evaluation of
+      the provided lambda term?
+
+    context: |
+
+      (x => f => s => f (x(f)(s))) (f => x => x)
+
+    answer: |
+
+      By the definition of the lambda calculus, here are the steps to evaluate
+      the given term:
+
+         (x => f => s => f (x(f)(s))) (f => x => x)
+      -> (     f => s => f ((f => x => x)(f)(s)))
+      -> (     f => s => f ((x => x) s))
+      -> (     f => s => f (s))
+      -> f => s => f (s)
+
+      This is the church numeral encoding for one.
+
+
+  - question: |
+
+      Using step by step equational reasoning, what is the evaluation of
+      the provided lambda term?
+
+    context: |
+
+      (x => x) (x => y => x)
+
+    answer: |
+
+      The given term applies the identity function, so it simply returns its
+      argument:
+
+         (x => x) (x => y => x)
+      -> (x => y => x)


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

The model is not able to perform equational reasoning.
This PR provides the following skill:

- Step by step evaluation to explain lambda term.

**Input given at the prompt**


```
Using step by step equational reasoning, what is the evaluation of the following lambda term:
  `(x => x) (x => y => x)` ?
```


**Response that was received**

```
  Let's break down the given lambda term into smaller steps to evaluate it:

  1. The first argument `(x => x)` is a simple identity function that returns its input unchanged.
  2. The second argument `(x => y => x)` can be understood as follows:
     - The inner argument `y` is ignored as it is not used in the function definition.
     - The outer argument `x` is returned unchanged.
  3. Now, let's apply the second argument to the first argument using function application (which is left associative):
     - `((x => x) (x => y => x))` = `(x => x) (x)` (since we don't care about the ignored `y` argument)
  4. Finally, apply the first argument (identity function) to the result from step 3:
     - `((x => x) (x))` = `x` (which is the input variable)

  Therefore, the final evaluation of the given lambda term `(x => x) (x => y => x)` is `x`.
```


**Response that is now received instead**

I did not run the updated model because I don't have the hardware, but the model was confused on step 3,
it should have said:

```
  3. Now, let's apply the second argument to the first argument using function application (which is left associative):

  Therefore, the final evaluation of the given lambda term `(x => x) (x => y => x)` is `(x => y => x)`.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
