### PR TITLE
Add a skill to count capital words in a text

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 If your PR is related to a contribution to the taxonomy, please, fill
-out the following questionaire. If not, replace this whole text and the
-following questionaire with whatever information is applicable to your PR.
+out the following questionnaire. If not, replace this whole text and the
+following questionnaire with whatever information is applicable to your PR.
 
 
 **Describe the contribution to the taxonomy**

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,14 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main 
+      - main
+    paths:
+      - 'compositional_skills/**/qna.yaml'
   pull_request:
     branches:
       - main
+    paths:
+      - 'compositional_skills/**/qna.yaml'
 
 jobs:
   lint:

--- a/compositional_skills/extraction/inference/quantitative/capital_letter_count/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/capital_letter_count/qna.yaml
@@ -1,0 +1,10 @@
+---
+created_by: dmranck
+seed_examples:
+  - answer: The text "Hello World" contains two capital letters. The capital letters are 'H' and 'W'.
+    question: How many capital letters are in the text "Hello World"?
+  - answer: The text "There should be SEVEN Capital letters returned" contains seven capital letters. The capital letters are 'T', 'S', 'E', 'V', 'E', 'N', and 'C'.
+    question: How many capital letters are in the text "There should be SEVEN Capital letters returned"?
+  - answer: The text "there are zero capital letters" contains zero capital letters.
+    question: How many capital letters are in the text "there are zero capital letters"?
+task_description: Ability to count capital letters in a given text.


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- A skill to count the capital letters in text. The current implementation had a few bugs (described below).


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   How many capital letters are in the text "Hello World"?
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  The text "Hello World" contains one capital letter, which is 'H' at the beginning of the word 'Hello'.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  The text "Hello World" contains two capital letters. The capital letters are 'H' and 'W'.
```

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   How many capital letters are in the text "There should be SEVEN Capital letters returned"?
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  The text "There should be SEVEN Capital letters returned" contains seven capital letters, as stated in the question itself. The capital letters are 'S', 'E', 'V', 'E', 'N', 'C', and 'R'.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  The text "There should be SEVEN Capital letters returned" contains seven capital letters. The capital letters are 'T', 'S', 'E', 'V', 'E', 'N', and 'C'.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] tested contribution with `lab generate`
- [ ] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
