### PR TITLE
Add skill for recipe unit conversion

### DIFF
--- a/compositional_skills/extraction/inference/quantitative/recipe_units/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/recipe_units/qna.yaml
@@ -1,0 +1,25 @@
+created_by: stefanhaRH
+seed_examples:
+- answer: |
+    - 237 ml all-purpose flour
+    - 474 ml milk
+    - 15 ml tablespoon vegetable oil
+    - 2.5 ml salt
+  context: |
+    - 1 cup all-purpose flour
+    - 2 cups milk
+    - 1 tablespoon vegetable oil
+    - 1/2 teaspoon salt
+  question: |
+    Convert the units in this list of recipe ingredients to milliliters.
+- answer: |
+    - 2 oz butter
+    - 1 oz sugar
+    - 1 lb breadcrumbs
+  context: |
+    - 57g butter
+    - 28g sugar
+    - 453g breadcrumbs
+  question: |
+    Convert these recipe ingredients from from metric to imperial.
+task_description: ''


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

When cooking or baking it is often convenient to convert units depending on what measurements you prefer and which measuring tools you have available.

**Input given at the prompt**

```
>>> Convert these recipe ingredients from from metric to imperial:\n- 57g butter\n- 28g sugar\n- 453g breadcrumbs
```

**Response that was received**

```
...
1 cup of breadcrumbs is approximately equal to 40 grams, so:
453 grams of breadcrumbs is equal to approximately 11.3 cups of breadcrumbs.
```

11.3 cups is far too much.

**Response that is now received instead**

I do not have access to hardware for generating data and training so this commit is untested.

**Contribution checklist**

- [ ] tested contribution with `lab generate`
- [ ] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)