### PR TITLE
Add skill to convert text into kebab case format

### DIFF
--- a/compositional_skills/writing/freeform/technical/kebab_case/attribution.txt
+++ b/compositional_skills/writing/freeform/technical/kebab_case/attribution.txt
@@ -1,0 +1,1 @@
+self-authored

--- a/compositional_skills/writing/freeform/technical/kebab_case/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/kebab_case/qna.yaml
@@ -1,0 +1,29 @@
+created_by: Mohit-Gaur
+seed_examples:
+  - answer: the-quick-brown-fox-jumped-over-the-lazy-dog
+    question: "Convert this text to kebab-case format: the quick brown fox jumped
+    over the lazy dog"
+  - answer: the-quick-brown-fox-jumped-over-the-lazy-dog
+    question: "Convert this text to kebab-case form: The Quick Brown Fox Jumped Over
+    The Lazy Dog"
+  - answer: the-quick-brown-fox-jumped-over-the-lazy-dog
+    question: "Convert this text to kebab case format: THE QUICK BROWN FOX JUMPED
+    OVER THE LAZY DOG"
+  - answer: the-quick-brown-fox-jumped-over-the-lazy-dog
+    question: "Convert this text to kebab case form:
+    the_quick_brown_fox_jumped_over_the_lazy_dog"
+  - answer: check-out-my-website
+    question: "Transform this text to kebab case format: Check out my website"
+  - answer: ml-is-a-subset-of-artificial-intelligence
+    question: "Transform this text to kebab-case format: ML is a subset of
+    artificial intelligence"
+  - answer: is-unread
+    question: "Change this text to kebab-case format: is Unread"
+  - answer: this-is-the-title-of-the-document
+    question: "Change this text to kebab case format: This is the title of the document"
+  - answer: image-file-name
+    question: "Modify this text to kebab-case format: image file name"
+  - answer: sql-databases-use-tables-to-store-data
+    question: "Modify this text to kebab case format: SQL databases use tables to
+      store data"
+task_description: Converts a given piece of text into kebab case format


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Added a new skill that converts a given text into kebab case format.


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
Convert this text to kebab-case format: the quick brown fox jumped over the lazy dog
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
The given text \"the quick brown fox jumped over the lazy dog\" is already in kebab case format, as it uses hyphens (-) to separate words. No conversion is required for this format.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
the-quick-brown-fox-jumped-over-the-lazy-dog
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)