### PR TITLE
quantitive: recognize function solutions given in context

### DIFF
--- a/compositional_skills/extraction/inference/quantitative/function_solution/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/function_solution/qna.yaml
@@ -1,0 +1,29 @@
+created_by: markmc
+seed_examples:
+  - answer: |
+      x = 2 is one solution to f(x) = 0.
+    context: |
+      The value of f(2) is 0.
+    question: |
+      Find x such that f(x) = 0.
+  - answer: |
+      The solutions to f(x) = 0 are x = -4, x = 3, and x = 5.
+    context: |
+      Given the function f(x) = x^3 - 4x^2 - 17x + 60 we might find by graphing
+      the function that f(3) = 0, f(5) = 0, and f(-4) = 0.
+    question: |
+      What are the solutions to the function f(x) = 0?
+  - answer: |
+      x = 5 is a root of f(x).
+    context: |
+      We are given a function f(x) and the information that f(5) = 0.
+    question: |
+      Given one root of the function f(x).
+  - answer: |
+      x=1 and x=2 are the solutions of f(x) = 0.
+    context: |
+      The function f(x) = x^2 - 3x + 2 has factors (x-1) and (x-2).
+    question: |
+      What are the solutions of f(x) = 0?
+task_description: |
+  Extracting the solution of a function where it is given in the context.


### PR DESCRIPTION
An interesting exchange happens with MT-Bench math#120 and several models:

> User: Given that f(x) = 4x^3 - 9x - 14, find the value of f(2).
>
> Assistant:
> Okay, let’s solve this step-by-step:
>
> Given: f(x) = 4x^3 - 9x - 14
>
> We want to find f(2), which means we substitute 2 for x: f(2) = 4(2)^3 - 9(2) - 14
>
> Simplify: f(2) = 4(8) - 18 - 14 = 32 - 18 - 14 = 32 - 32 = 0
>
> Therefore, the value of f(2) is 0.
>
> User follow-up: Find x such that f(x) = 0.

Of course, at this point, a human would notice that the assistant should have recognized from its first answer that x = 2 is one solution (in fact it is the only real solution).

So this is an example where perhaps a model could perform better on the MT-Bench if it could be thought to recognize when a solution for a function has been given rather than attempting to "do the math" to work out the solution itself.