### PR TITLE
Add a skill to represent IPv6 addresses using the compressed format

### DIFF
--- a/compositional_skills/writing/freeform/technical/ipv6/qna.yml
+++ b/compositional_skills/writing/freeform/technical/ipv6/qna.yml
@@ -1,0 +1,18 @@
+created_by: dcaratti
+seed_examples:
+- answer: >
+    Leading zeros MUST be suppressed. "2001:0db8::0001" is not acceptable and must be represented
+    as "2001:db8::1"
+  question: >
+    How do I represent an address where some 16-bit groups have leading zeros?
+- answer: >
+    The use of the symbol "::" MUST be used to its maximum capability. For example,
+    2001:db8:0:0:0:0:2:1 must be shortened to 2001:db8::2:1.
+  question: >
+    How many groups can be shortened using the symbol "::"?
+- answer: >
+    The symbol "::" is used to suppress more than one 16-bit groups made of zeros. The symbol "::"
+    MUST NOT be used to shorten just one 16-bit group.
+  question: >
+    What is the purpose of symbol "::"?
+task_description: 'represent IPv6 addresses using compressed format according to RFC 5952'


### PR DESCRIPTION
Use recommendations from RFC5952 to print IPv6 addresses

**Describe the contribution to the taxonomy**

- omit leading zeros
- use the "::" symbol to shorten groups made of zeros
- shorten as many groups as possible
- don't shorten single groups,

**Input given at the prompt**
```
>>> how do I express 2001:0db8:0a0b:12f0:0000:0001:0000:0001 in compressed annotation?                             [S]
```
**Response that was received**
```
[default]
╭─────────────────────────────────────────────── ggml-merlinite-7b-0302-Q4_K_M ───────────────────────────────────────────────╮
│ To represent the IPv6 address 2001:0db8:0a0b:12f0:0000:0001:0000:0001 in compressed notation, we can omit leading zeroes    │
│ and consecutive repetitions of sections. The resulting compressed notation is:                                              │
│                                                                                                                             │
│ 2001:db8:a0b:12f0::1:0:0:1                                                                                                  │
│                                                                                                                             │
│ Here, the leading zeroes in the first section have been omitted, and the first four sections, as well as the last three     │
│ sections, are represented as a single section, as there is no repetition or leading zeroes in these sections. The second    │
│ last section has one zero, which is kept, and the last section has one zero, which is kept as well.                         │
╰──────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 38.705 seconds ─╯
```
**Response that is now received instead**

(test still in progress. lab generate takes hours here and it often exits with timeout)

**Contribution checklist**

- [ ] tested contribution with `lab generate`
- [ ] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
