### PR TITLE
Add a skill to generate allow rule from SELinux denial

### DIFF
--- a/compositional_skills/writing/freeform/technical/generate_selinux_allow_rules/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/generate_selinux_allow_rules/qna.yaml
@@ -1,0 +1,33 @@
+created_by: wrabcak
+seed_examples:
+- answer: 'To generate an SELinux allow rule for the given denial, you can
+  manually construct the rule based on the denial information:
+  allow httpd_t samba_share_t:file getattr;'
+  question: 'Generate SELinux allow rule from the following SELinux denial:
+  type=AVC msg=audit(1226882736.442:86): avc:  denied  { getattr } for
+  pid=2427 comm="httpd" path="/var/www/html/file1" dev=dm-0 ino=284133
+  scontext=unconfined_u:system_r:httpd_t:s0
+  tcontext=unconfined_u:object_r:samba_share_t:s0 tclass=file'
+
+- answer: 'To generate an SELinux allow rule for the given denial, you can
+  manually construct the rule based on the denial information:
+  allow testapp_t http_port_t:tcp_socket name_connect;  '
+  question: 'Generate SELinux allow rule from the following SELinux denial:
+  type=AVC msg=audit(1552588580.769:25978): avc:  denied  { name_connect }
+  for  pid=1023 comm="testapp"
+  dest=80 scontext=system_u:system_r:testapp_t:s0
+  tcontext=system_u:object_r:http_port_t:s0 tclass=tcp_socket permissive=1'
+
+- answer: 'To generate an SELinux allow rule for the given denial, you can
+  manually construct the rule based on the denial information:
+  allow testapp_t proc_t:file { open read };'
+  question: 'Generate SELinux allow rule from the following SELinux denial
+  type=AVC msg=audit(1552588580.764:25971): avc:  denied  { open } for
+  pid=1022 comm="testapp" path="/proc/meminfo" dev="proc" ino=4026532040
+  scontext=system_u:system_r:testapp_t:s0 tcontext=system_u:object_r:proc_t:s0
+  tclass=file permissive=1
+  type=AVC msg=audit(1552588580.764:25971): avc:  denied  { read } for
+  pid=1022 comm="testapp" name="meminfo" dev="proc" ino=4026532040
+  scontext=system_u:system_r:testapp_t:s0 tcontext=system_u:object_r:proc_t:s0
+  tclass=file permissive=1'
+task_description: ''


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Add a skill to generate allow rule from SELinux denial

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
Generate allow rule from the following SELinux denial: "type=AVC msg=audit(1226882736.442:86): avc:  denied
{ getattr } for  pid=2427 comm="httpd" path="/var/www/html/file1" dev=dm-0 ino=284133
scontext=unconfined_u:system_r:httpd_t:s0 tcontext=unconfined_u:object_r:samba_share_t:s0 tclass=file"
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
To generate an allow rule for the given SELinux denial, we need to specify the SELinux context for the file, which is not
provided in the original message. However, I can provide you with a general template for creating an allow rule.

To create an allow rule, you can use the command `semanage`, which is a command-line tool for managing SELinux
policies. Here's a template for creating an allow rule for the given denial:

bash
semanage fcontext -a -t samba_share_t "/var/www/html/file1(/.*)?"

This command will add a new context to the SELinux policy, allowing the specified file to be accessed by the httpd process.
However, please note that this command assumes that the file is located in the `/var/www/html/` directory and has the
name `file1`. If the file is located in a different directory or has a different name, you will need to adjust the path in the
`semanage fcontext` command accordingly.
```

**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
To generate an SELinux allow rule for the given denial, you can manually construct the rule based on the denial
information: allow httpd_t samba_share_t:file getattr;
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [X] tested contribution with `lab generate`
- [X] `lab generate` does not produce any warnings or errors
- [X] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [X] the `qna.yaml` file was [linted](https://yamllint.com)