### PR TITLE
add skill to extract every other word

### DIFF
--- a/compositional_skills/extraction/linguistic/every_other/qna.yaml
+++ b/compositional_skills/extraction/linguistic/every_other/qna.yaml
@@ -1,0 +1,28 @@
+created_by: jstancek
+seed_examples:
+  - answer: It means each alternate in a series. For example "I practice piano
+      every other day."
+    question: What is the meaning of 'every other'?
+  - answer: hungry was
+    question: Give me every other word, starting with second word from sentence
+      "Dark hungry dog was lost."
+  - answer: fox over brown
+    question: Give me every other word, while keeping words at even positions
+      from text "lazy fox jumps over the brown dog"
+  - answer: lazy jumps the dog
+    question: Give me every other word, while keeping words at odd positions
+      from text "lazy fox jumps over the brown dog"
+  - answer: five wizards quickly.
+    question: Extract every other word from sentence "The five boxing wizards jump quickly."
+      Start with second word.
+  - answer: ipsum sit consectetuer elit earum hic a delectus, aut voluptatibus alias aut doloribus repellat.
+    question: Return every other word from text, start with second word "Lorem ipsum dolor sit amet,
+      consectetuer adipiscing elit Itaque earum rerum hic tenetur a sapiente
+      delectus, ut aut reiciendis voluptatibus maiores alias consequatur aut
+      perferendis doloribus asperiores repellat."
+  - answer: like and but bananas
+    question: Give me every word at even position from text "I like apples and oranges, but not bananas."
+  - answer: like and but bananas like and but bananas
+    question: Give me every other word from text "I like apples and oranges, but not bananas.
+      I like apples and oranges, but not bananas." Start with word "like".
+task_description: "To teach a language model about concept of every other words (at even or odd positions)."


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

Add skill to extract every other word. Current model doesn't seem to understand this request and just returns input.

**Input given at the prompt**

```
Extract every other word from sentence: The five boxing wizards jump quickly.
```


**Response that was received**

```
The five boxing wizards jump quickly.
```

**Input given at the prompt**

```
Give me every other word from text: lazy fox jumps over the brown dog
```


**Response that was received**

```
lazy fox jumps over the brown dog
```

**Response that is now received instead**

N/A atm., I'll add it if I'm able to retrain the model.

**Contribution checklist**

- [ x ] tested contribution with `lab generate`
- [ x ] `lab generate` does not produce any warnings or errors
- [ x ] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ x ] the `qna.yaml` file was [linted](https://yamllint.com)
