### PR TITLE
linguistic: Improve counting syllables in Portuguese

### DIFF
--- a/compositional_skills/extraction/linguistic/syllables/pt/qna.yaml
+++ b/compositional_skills/extraction/linguistic/syllables/pt/qna.yaml
@@ -1,0 +1,45 @@
+- question: Qual é a separação silábica da palavra averiguou em português?
+  answer: "In Portuguese, the word \"averiguou\" is divided into: a-ve-ri-guou."
+
+- question: Qual é a separação silábica da palavra fazer em português?
+  answer: "In Portuguese, the word \"fazer\" is divided into: fa-zer."
+
+- question: Qual é a separação silábica da palavra banheira em português?
+  answer: "In Portuguese, the word \"banheira\" is divided into: ba-nhei-ra."
+
+- question: Qual é a separação silábica da palavra caatinga em português?
+  answer: "In Portuguese, the word \"caatinga\" is divided into: ca-a-tin-ga."
+
+- question: Qual é a separação silábica da palavra alcoolismo em português?
+  answer: "In Portuguese, the word \"alcoolismo\" is divided into: al-co-o-lis-mo."
+
+- question: Qual é a separação silábica da palavra prefixo em português?
+  answer: "In Portuguese, the word \"prefixo\" is divided into: pre-fi-xo."
+
+- question: Qual é a separação silábica da palavra abdominal em português?
+  answer: "In Portuguese, the word \"abdominal\" is divided into: ab-do-mi-nal."
+
+- question: Qual é a separação silábica da palavra Brasília em português?
+  answer: "In Portuguese, the word \"Brasília\" is divided into: Bra-sí-li-a."
+
+- question: Qual é a separação silábica da palavra inconstitucionalissimamente em português?
+  answer: "In Portuguese, the word \"inconstitucionalissimamente\" is divided into:
+    in-cons-ti-tu-ci-o-na-lis-si-ma-men-te."
+
+- question: Qual é a separação silábica da palavra dignidade em português?
+  answer: "In Portuguese, the word \"dignidade\" is divided into: dig-ni-da-de."
+
+- question: Qual é a separação silábica da palavra guiar em português?
+  answer: "In Portuguese, the word \"guiar\" is divided into: gui-ar."
+
+- question: Qual é a separação silábica da palavra alho em português?
+  answer: "In Portuguese, the word \"alho\" is divided into: a-lho."
+
+- question: Qual é a separação silábica da palavra jaula em português?
+  answer: "In Portuguese, the word \"jaula\" is divided into: jau-la."
+
+- question: Qual é a separação silábica da palavra reino em português?
+  answer: "In Portuguese, the word \"reino\" is divided into: rei-no."
+
+- question: Qual é a separação silábica da palavra beato em português?
+  answer: "In Portuguese, the word \"beato\" is divided into: be-a-to."


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

Counting syllables in Portuguese needs a lot of improvements. Sometimes the count was correct, but the syllables were split wrongly. Many times both cases were wrong.
Sometimes I had the feeling it is applying rules from other languages when counting the syllables.
In other cases, the word was even written wrong (see the example below).

**Input given at the prompt**

I tested with all the words in this commit and noticed they all had issues.
Not all of them have 100% improved results though.
One example is the word `caatinga`.

```
Quantas sílabas tem a palavra caatinga?
```


**Response that was received**

Notice how the word is written wrong in the output:

```
>>> Quantas sílabas tem a palavra caatinga?                                                       [S][default]
╭─────────────────────────────────────────── merlinite-7b-Q4_K_M ────────────────────────────────────────────╮
│ In Portuguese, the word "caatinga" has two syllables: ca-ta-nga. The first syllable (ca) is stressed in    │
│ the word. The stress pattern in Portuguese words can influence the pronunciation and intonation of the     │
│ word, making it easier for listeners to understand the word's meaning. The word "caatinga" is often used   │
│ in Portuguese to refer to a type of dense, tropical vegetation found in Brazil.                            │
╰─────────────────────────────────────────────────────────────────────────────────── elapsed 12.845 seconds ─╯
```


**Response that is now received instead**

The amount of syllables is correct now (4), the output does include all the characters in proper order, but it's still not splitting the syllables correctly:

```
>>> Quantas sílabas tem a palavra caatinga?                                                       [S][default]
╭─────────────────────────────────────────── merlinite-7b-Q4_K_M ────────────────────────────────────────────╮
│ A palavra "caatinga" é composta por quatro sílabas no idioma português: Ca-at-ing-a. A letra "a" final é   │
│ muda e, portanto, não é contada como uma sílaba separada. Além disso, a letra "t" é pronunciada e é parte  │
│ da sílaba "at", mas não é contada como uma letra separada na tabela de sílabas.                            │
│                                                                                                            │
│ Aqui está uma tabela de exemplo para ilustrar como identificar as sílabas em uma palavra:                  │
│                                                                                                            │
│ | Palavra | Sílabas |                                                                                      │
│ | --- | --- |                                                                                              │
│ | abdominal | A-bdo-mi-nal |                                                                               │
│ | Brasília | Bra-si-lí-a |                                                                                 │
│ | caatinga | Ca-at-ing-a |                                                                                 │
│ | amarelo | A-ma-ré-lo |                                                                                   │
│                                                                                                            │
│ A letra "a" final é muda, o que significa que não é pronunciada e, portanto, não é contada como uma sílaba │
│ separada. Além disso, a letra "t" é pronunciada e é parte da sílaba "at", mas não é contada como uma letra │
│ separada na tabela de sílabas.                                                                             │
│                                                                                                            │
│ No entanto, é importante notar que o número de sílabas em uma palavra pode variar dependendo do contexto e │
│ da pronúncia específics, então é possível que algumas pessoas possam classificar "caatinga" como tendo     │
│ três sílabas, dependendo da sua pronúncia e interpretação das regras de separação silábica no idioma       │
│ português.                                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────── elapsed 60.273 seconds ─╯
```

The table in the end is not completely correct either.
I've also seen cases where this table has random data, e.g.:

```
│ | Palavra | Sílabas |                                                                                      │
│ | --- | --- |                                                                                              │
│ | abdominal | A-bdo-mi-nal |                                                                               │
│ | Brasília | Bra-si-lí-a |                                                                                 │
│ |<dummy00001> | In-ti-ni-zam | 
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
