### PR TITLE
Add inference proof writing skill

### DIFF
--- a/compositional_skills/writing/freeform/mathematical/proofs/inference/qna.yaml
+++ b/compositional_skills/writing/freeform/mathematical/proofs/inference/qna.yaml
@@ -1,0 +1,100 @@
+---
+created_by: taagarwa-rh
+seed_examples:
+  - answer: >-
+      Let n, m be odd integers. Then there exists integers a and b such that n
+      = 2a + 1 and m = 2b + 1. Then consider
+
+
+      n + m
+
+      = (2a + 1) + (2b + 1)    Substitution
+
+      = 2a + 2b + 1 + 1        Associativity
+
+      = 2a + 2b + 2            Algebra
+
+      = 2(a + b + 1)           Factoring
+
+
+      By definition, 2(a + b + 1) is an even number therefore n + m is even.
+
+
+      Q.E.D.
+    question: "Prove the following statement: if two integers are odd, then their
+      sum is even."
+  - answer: >-
+      Let n be an odd integer. Then there exists an integer k such that n = 2k
+      + 1. Then consider
+
+      n^2
+
+      = (2k + 1)^2          Substitution
+
+      = 4k^2 + 4k + 1       Algebra
+
+      = 2(2k^2 + 2k) + 1    Factoring
+
+
+      Since k is an integer, 2k^2 + 2k is also an integer. So by definition, n^2 is odd.
+
+
+      Q.E.D.
+    question: "Prove the following statement: If n is an odd integer, then n^2 is
+      also odd."
+  - answer: >-
+      Let n be an odd integer. Then there exists an integer k such that n = 2k
+      + 1. Then consider
+
+
+      n^2
+
+      = (2k + 1)^2          Substitution
+
+      = 4k^2 + 4k + 1       Algebra
+
+
+      Now from the above result, to show that n^2 is congruent to 1 modulo 8, it suffices to show: 8 | (4k^2 + 4k)
+
+      4k^2 + 4k
+
+      = 4k(k + 1)           Factoring
+
+
+      Hence, 4 | (4k^2 + 4k)
+
+      Now since 8 = 4 * 2. all that remains to show is: 2 | k(k + 1)
+
+
+      Case 1: k is even.
+
+      Since k is even, then there exists an integer l such that k = 2l
+
+      k(k + 1)
+
+      2l(2l + 1)           Substitution
+
+      2(2l^2 + l)          Distribution
+
+      Since l is an integer, 2l^2 + l is also an integer. So by definition, k(k + 1) is even.
+
+
+      Case 2: k is odd.
+
+      Since k is odd, then there exists an integer l such that k = 2l + 1
+
+      k(k + 1)
+
+      (2l + 1)(2l + 2)     Substitution
+
+      2(2l + 1)(l + 1)     Factoring
+
+      Since l is an integer, (2l + 1)(l + 1) is also an integer. So by definition k(k + 1) is even.
+
+      Thus we have that 8 | (4k^2 + 4k).
+
+
+      Q.E.D.
+    question: "Prove the following statement: If n is an odd integer, then n^2 is
+      congruent to 1 modulo 8."
+task_description: This skill provides the ability to write mathematical inference proofs.


### PR DESCRIPTION
---------
Signed-off-by: Taylor Agarwal <taagarwa@redhat.com>, Alex Raum <mraum@redhat.com>

**Describe the contribution to the taxonomy**

- Add a skill for writing inference proofs in the mathematically standard format


**Input given at the prompt**

```
Prove the following statement: the sum of two odd numbers is even.
```


**Response that was received**

```
To prove that the sum of two odd numbers is even, let's first define what we mean by an odd number. An odd number is a number that cannot be divided exactly by 2, leaving no remainder. For example, 1, 3, 5, 7, and 9 are all odd numbers.

Let's take two arbitrary odd numbers, which we can call x and y. By definition, both x and y cannot be divided exactly by 2, so they must both be odd numbers.

Now, let's calculate their sum:

x + y

To prove that this sum is even, we need to show that it can be divided exactly by 2, leaving no remainder. We can do this by rewriting x and y as even numbers plus 1. This is because any odd number can be expressed as 2n + 1, where n is an integer.

So, we have:

x = 2n1 + 1
y = 2n2 + 1

Now, let's calculate their sum:

x + y = (2n1 + 1) + (2n2 + 1)
x + y = 2n1 + 2n2 + 2

Now, we can factor out a 2 from the sum:

x + y = 2(n1 + n2 + 1)

Since n1 and n2 are integers, their sum (n1 + n2 + 1) is also an integer. We can now multiply this integer by 2 to get our final result:

x + y = 2 * (integer)

Since x + y can be expressed as 2 times an integer, it means that x + y can be divided exactly by 2, leaving no remainder. Therefore, the sum of two odd numbers is indeed even, as stated in the original claim.
```


**Response that is now received instead**

```
Let o1, o2 be odd numbers, then there exists integers m, n such that o1 = 2m + 1, o2 = 2n + 1. Then their sum:
o1 + o2 = (2m + 1) + (2n + 1) = 2m + 2n + 1 + 1 = 2(m + n + 1) = even    // Q.E.D.
```

**Contribution checklist**

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
