### PR TITLE
Add stacktrace extraction skill

### DIFF
--- a/compositional_skills/extraction/information/debug/stacktrace/qna.yaml
+++ b/compositional_skills/extraction/information/debug/stacktrace/qna.yaml
@@ -1,0 +1,81 @@
+# The goal of this skill is to extract information from stacktraces
+---
+task_description: |
+
+  Extract information from stacktrace errors
+
+created_by: TristanCacqueray
+
+seed_examples:
+  - question: |
+
+      What is the filename and line number of the Python stacktrace?
+
+    context: |
+
+      Traceback (most recent call last):
+        File "cli/config.py", line 85, in read_config
+          return Config(**cfg)
+      TypeError: __init__() got an unexpected keyword argument 'list')))
+
+
+    # The model used to reply
+    # `The given stacktrace does not include the filename for ...`
+    answer: |
+
+      The given stacktrace is coming from the file named "cli/config.py"
+      line 85.
+
+  - question: |
+
+      What is the filename and line number of the provided stacktrace origin?
+
+    context: |
+
+      Traceback (most recent call last):
+        File "test.py", line 7, in <module>
+          main()
+        File "test.py", line 5, in main
+          fib(n)
+        File "test.py", line 2, in fib
+          return 42 / n
+                 ~~~^~~
+      ZeroDivisionError: division by zero
+
+    answer: |
+
+      The given stacktrace is coming from the file named "test.py" line 2.
+
+  - question: |
+
+      What is the filename and line number of the provided stacktrace origin?
+
+    context: |
+
+      Traceback (most recent call last):
+        File "site-packages/httpx/_transports/default.py", line 69, in map_httpcore_exceptions
+          yield
+        File "site-packages/httpx/_transports/default.py", line 113, in __iter__
+          for part in self._httpcore_stream:
+        File "site-packages/httpcore/_sync/connection_pool.py", line 367, in __iter__
+          raise exc from None
+        File "site-packages/httpcore/_sync/connection_pool.py", line 363, in __iter__
+          for part in self._stream:
+        File "site-packages/httpcore/_sync/http11.py", line 349, in __iter__
+          raise exc
+        File "site-packages/httpcore/_sync/http11.py", line 341, in __iter__
+          for chunk in self._connection._receive_response_body(**kwargs):
+        File "site-packages/httpcore/_sync/http11.py", line 210, in _receive_response_body
+          event = self._receive_event(timeout=timeout)
+                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        File "site-packages/httpcore/_sync/http11.py", line 220, in _receive_event
+          with map_exceptions({h11.RemoteProtocolError: RemoteProtocolError}):
+        File "/usr/lib64/python3.12/contextlib.py", line 158, in __exit__
+          self.gen.throw(value)
+        File "site-packages/httpcore/_exceptions.py", line 14, in map_exceptions
+          raise to_exc(exc) from exc
+      httpcore.RemoteProtocolError: peer closed connection without sending complete message body (incomplete chunked read)
+
+    answer: |
+
+      The given stacktrace is coming from the file named "httpcore/_sync/http11.py" line 210.


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

- Extract information from stacktrace errors


**Input given at the prompt**

```
>>> What is the filename and line number of the Python stacktrace? `Traceback (most recent call last):\n  File "cli/config.py", line 85, in read_config\n    return Config(**cfg)\nTypeError: __init__() got an unexpected keyword argument 'list')))`
```


**Response that was received**

```
 The given stacktrace source does not include the filename for the TypeError exception. However, I can provide information about the other frames in the stacktrace:

 ``python                                                                                                                                                                                                                                                                                                                                                                                 
 Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                                
   File "/usr/local/InstructLab/venv/lib/python3.9/site-packages/cli/config.py", line 85, in read_config                                                                                                                                                                                                                                                                                   
     return Config(**cfg)                                                                                                                                                                                                                                                                                                                                                                  
 TypeError: __init__() got an unexpected keyword argument 'list'                                                                                                                                                                                                                                                                                                                           
 ``                                                                                                                                                                                                                                                                                                                                                                                     
 The first frame in the stacktrace is `/usr/local/InstructLab/venv/lib/python3.9/site-packages/cli/config.py`, which is the file for the `read_config` function. The line number is 85.                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                           
 The second frame is `<module>`, which indicates that the error occurred in the current module being executed, but no specific line number is provided.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                          
 The third frame is `read_config`, which is the function being executed when the error occurred.                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                           
 The last frame is `<module>`, which is the main module being executed.                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                                          
 Please note that I cannot provide the filename for the TypeError exception since it is not included in the provided stacktrace. 
```


**Response that is now received instead**

I did not run the updated model because I don't have the hardware, but the model was confused on step 3,
it should have said:

```
The filename is `cli/config.py`, and the line number is 85.
```

**Contribution checklist**

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
