### PR TITLE
Add skill for table manipulation

### DIFF
--- a/compositional_skills/extraction/inference/quantitative/table_manipulation/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/table_manipulation/qna.yaml
@@ -1,0 +1,40 @@
+created_by: dolfim-ibm
+seed_examples:
+- answer: 'Column 1, Column 2, Column 3'
+  context: |
+    | Column 1  | Column 2  | Column 3  |
+    |-----------|-----------|-----------|
+    | 1         | 2         | 3         |
+    | 4         | 5         | 6         |
+  question: 'what are the headers of this table?'
+- answer: 'Rank, Company, Country, Industry'
+  context: |
+    | **Rank**  | **Company**    | **Country**    | **Industry**                     |
+    | 1         | Walmart        | United States  | Retail                           |
+    | 2         | Saudi Aramco   | Saudi Arabia   | Energy                           |
+    | 3         | State Grid     | China          | Energy                           |
+    | 4         | Amazon         | United State   | Internet services and retailing  |  
+  question: 'what are the headers of this table?'
+- answer: |
+    | 1     | Walmart       | United States  | Retail |
+    | 2     | Saudi Aramco  | Saudi Arabia   | Energy |
+  context: |
+    | **Rank**  | **Company**    | **Country**    | **Industry**                     |
+    | 1         | Walmart        | United States  | Retail                           |
+    | 2         | Saudi Aramco   | Saudi Arabia   | Energy                           |
+    | 3         | State Grid     | China          | Energy                           |
+    | 4         | Amazon         | United State   | Internet services and retailing  |  
+  question: 'what are the top 2 rows?'
+- answer: |
+    | 4         | 5         | 6         |
+    | 7         | 8         | 9         |
+  context: |
+    | Column 1  | Column 2  | Column 3  |
+    |-----------|-----------|-----------|
+    | 1         | 2         | 3         |
+    | 4         | 5         | 6         |
+    | 7         | 8         | 9         |
+    | 10        | 11        | 12        |
+  question: 'what are the second and third rows?'
+
+task_description: 'Manipulate tables applying filters based on the table structure.'

--- a/compositional_skills/extraction/inference/quantitative/table_manipulation/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/table_manipulation/qna.yaml
@@ -1,40 +1,50 @@
+---
 created_by: dolfim-ibm
 seed_examples:
-- answer: 'Column 1, Column 2, Column 3'
-  context: |
-    | Column 1  | Column 2  | Column 3  |
-    |-----------|-----------|-----------|
-    | 1         | 2         | 3         |
-    | 4         | 5         | 6         |
-  question: 'what are the headers of this table?'
-- answer: 'Rank, Company, Country, Industry'
-  context: |
-    | **Rank**  | **Company**    | **Country**    | **Industry**                     |
-    | 1         | Walmart        | United States  | Retail                           |
-    | 2         | Saudi Aramco   | Saudi Arabia   | Energy                           |
-    | 3         | State Grid     | China          | Energy                           |
-    | 4         | Amazon         | United State   | Internet services and retailing  |  
-  question: 'what are the headers of this table?'
-- answer: |
-    | 1     | Walmart       | United States  | Retail |
-    | 2     | Saudi Aramco  | Saudi Arabia   | Energy |
-  context: |
-    | **Rank**  | **Company**    | **Country**    | **Industry**                     |
-    | 1         | Walmart        | United States  | Retail                           |
-    | 2         | Saudi Aramco   | Saudi Arabia   | Energy                           |
-    | 3         | State Grid     | China          | Energy                           |
-    | 4         | Amazon         | United State   | Internet services and retailing  |  
-  question: 'what are the top 2 rows?'
-- answer: |
-    | 4         | 5         | 6         |
-    | 7         | 8         | 9         |
-  context: |
-    | Column 1  | Column 2  | Column 3  |
-    |-----------|-----------|-----------|
-    | 1         | 2         | 3         |
-    | 4         | 5         | 6         |
-    | 7         | 8         | 9         |
-    | 10        | 11        | 12        |
-  question: 'what are the second and third rows?'
+  - answer: Column 1, Column 2, Column 3
+    context: |
+      | Column 1  | Column 2  | Column 3  |
+      |-----------|-----------|-----------|
+      | 1         | 2         | 3         |
+      | 4         | 5         | 6         |
+    question: what are the headers of this table?
+  - answer: Rank, Company, Country, Industry
+    context: >
+      | **Rank**  | **Company**    | **Country**    |
+      **Industry**                     |
 
-task_description: 'Manipulate tables applying filters based on the table structure.'
+      | 1         | Walmart        | United States  | Retail                           |
+
+      | 2         | Saudi Aramco   | Saudi Arabia   | Energy                           |
+
+      | 3         | State Grid     | China          | Energy                           |
+
+      | 4         | Amazon         | United State   | Internet services and retailing  |  
+    question: what are the headers of this table?
+  - answer: |
+      | 1     | Walmart       | United States  | Retail |
+      | 2     | Saudi Aramco  | Saudi Arabia   | Energy |
+    context: >
+      | **Rank**  | **Company**    | **Country**    |
+      **Industry**                     |
+
+      | 1         | Walmart        | United States  | Retail                           |
+
+      | 2         | Saudi Aramco   | Saudi Arabia   | Energy                           |
+
+      | 3         | State Grid     | China          | Energy                           |
+
+      | 4         | Amazon         | United State   | Internet services and retailing  |  
+    question: what are the top 2 rows?
+  - answer: |
+      | 4         | 5         | 6         |
+      | 7         | 8         | 9         |
+    context: |
+      | Column 1  | Column 2  | Column 3  |
+      |-----------|-----------|-----------|
+      | 1         | 2         | 3         |
+      | 4         | 5         | 6         |
+      | 7         | 8         | 9         |
+      | 10        | 11        | 12        |
+    question: what are the second and third rows?
+task_description: Manipulate tables applying filters based on the table structure.

--- a/compositional_skills/extraction/inference/quantitative/table_manipulation/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/table_manipulation/qna.yaml
@@ -1,41 +1,31 @@
 ---
 created_by: dolfim-ibm
 seed_examples:
-  - answer: Column 1, Column 2, Column 3
+  - answer: 'Column 1, Column 2, Column 3'
     context: |
       | Column 1  | Column 2  | Column 3  |
       |-----------|-----------|-----------|
       | 1         | 2         | 3         |
       | 4         | 5         | 6         |
-    question: what are the headers of this table?
-  - answer: Rank, Company, Country, Industry
-    context: >
-      | **Rank**  | **Company**    | **Country**    |
-      **Industry**                     |
-
+    question: 'what are the headers of this table?'
+  - answer: 'Rank, Company, Country, Industry'
+    context: |
+      | **Rank**  | **Company**    | **Country**    | **Industry**                     |
       | 1         | Walmart        | United States  | Retail                           |
-
       | 2         | Saudi Aramco   | Saudi Arabia   | Energy                           |
-
       | 3         | State Grid     | China          | Energy                           |
-
-      | 4         | Amazon         | United State   | Internet services and retailing  |  
-    question: what are the headers of this table?
+      | 4         | Amazon         | United State   | Internet services and retailing  |
+    question: 'what are the headers of this table?'
   - answer: |
       | 1     | Walmart       | United States  | Retail |
       | 2     | Saudi Aramco  | Saudi Arabia   | Energy |
-    context: >
-      | **Rank**  | **Company**    | **Country**    |
-      **Industry**                     |
-
+    context: |
+      | **Rank**  | **Company**    | **Country**    | **Industry**                     |
       | 1         | Walmart        | United States  | Retail                           |
-
       | 2         | Saudi Aramco   | Saudi Arabia   | Energy                           |
-
       | 3         | State Grid     | China          | Energy                           |
-
-      | 4         | Amazon         | United State   | Internet services and retailing  |  
-    question: what are the top 2 rows?
+      | 4         | Amazon         | United State   | Internet services and retailing  |
+    question: 'what are the top 2 rows?'
   - answer: |
       | 4         | 5         | 6         |
       | 7         | 8         | 9         |
@@ -46,5 +36,6 @@ seed_examples:
       | 4         | 5         | 6         |
       | 7         | 8         | 9         |
       | 10        | 11        | 12        |
-    question: what are the second and third rows?
-task_description: Manipulate tables applying filters based on the table structure.
+    question: 'what are the second and third rows?'
+
+task_description: 'Manipulate tables applying filters based on the table structure.'


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Get the headers of the table
- Get the top rows of a table
- Other types of manipulation based on the geometry structure of a table


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
what are the headers of this table?                                                                                                                                                         [S][default]
| Column 1  | Column 2  | Column 3  |
|-----------|-----------|-----------|
| 1         | 2         | 3         |
| 4         | 5         | 6         |
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  ╭────────────────────────────────────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ───────────────────────────────────────────────────────────────────────────────────────────╮
│ The table does not have any visible headers. I'm sorry for any confusion, but I cannot provide information that is not present in the input data.                                                        │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 9.315 seconds ─╯

```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

`lab generate` completed, but without a M-series mac I cannot test this out.

```
  ... not possible ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
