### PR TITLE
skill: storage unit conversion

### DIFF
--- a/compositional_skills/extraction/inference/quantitative/units/storage/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/units/storage/qna.yaml
@@ -1,0 +1,120 @@
+created_by: leseb
+seed_examples:
+- answer: |
+    1 Kilobyte is equal to (103 / 210) kibibytes.
+    There are 0.9765625 kibibytes in a Kilobyte.
+  question: 'How many Kibibytes in a Kilobyte?'
+  context: ''
+- answer: |
+    - 0.9765625 KiB
+    - 1.953125 KiB
+    - 2.9296875 KiB
+    - 3.90625 KiB
+    - 4.8828125 KiB
+    - 5.859375 KiB
+    - 6.8359375 KiB
+    - 7.8125 KiB
+    - 8.7890625 KiB
+    - 9.765625 KiB
+  context: |
+    - 1 KB
+    - 2 KB
+    - 3 KB
+    - 4 KB
+    - 5 KB
+    - 6 KB
+    - 7 KB
+    - 8 KB
+    - 9 KB
+    - 10 KB
+  question: 'convert the following KB units to KiB'
+- answer: |
+    1 Megabyte is equal to (106 / 220) mebibytes.
+    There are 0.95367431640625 mebibytes in a Megabyte.
+  question: 'How many Mebibytes in a Megabyte?'
+  context: ''
+- answer: |
+    - 0.95367431640625 MiB
+    - 1.9073486328125 MiB
+    - 2.8610229492188 MiB
+    - 3.814697265625 MiB
+    - 4.7683715820312 MiB
+    - 5.7220458984375 MiB
+    - 6.6757202148438 MiB
+    - 7.62939453125 MiB
+    - 8.5830688476562 MiB
+    - 9.5367431640625 MiB
+  context: |
+    - 1 MB
+    - 2 MB
+    - 3 MB
+    - 4 MB
+    - 5 MB
+    - 6 MB
+    - 7 MB
+    - 8 MB
+    - 9 MB
+    - 10 MB
+  question: 'convert the following MB units to MiB'
+- answer: |
+    1 Gigabyte is equal to (109 / 230) gibibytes.
+    There are 0.93132257461548 gibibytes in a Gigabyte.
+  question: 'How many Gibibytes in a Gigabyte?'
+  context: ''
+- answer: |
+    - 0.9313 GiB
+    - 1.8626 GiB
+    - 2.7939 GiB
+    - 3.7252 GiB
+    - 4.6566 GiB
+    - 5.5879 GiB
+    - 6.5192 GiB
+    - 7.4505 GiB
+    - 8.3819 GiB
+    - 9.3132 GiB
+  context: |
+    - 1 GB
+    - 2 GB
+    - 3 GB
+    - 4 GB
+    - 5 GB
+    - 6 GB
+    - 7 GB
+    - 8 GB
+    - 9 GB
+    - 10 GB
+  question: 'convert the following GB units to GiB'
+- answer: |
+    1 Terabyte is equal to (1012 / 240) tebibytes.
+    There are 0.90949470177293 tebibytes in a Terabyte.
+  question: 'How many Tebibytes in a Terabyte?'
+  context: ''
+- answer: |
+    - 0.90949470177293 TiB
+    - 1.8189894035459 TiB
+    - 2.7284841053188 TiB
+    - 3.6379788070917 TiB
+    - 4.5474735088646 TiB
+    - 5.4569682106376 TiB
+    - 6.3664629124105 TiB
+    - 7.2759576141834 TiB
+    - 8.1854523159564 TiB
+    - 9.0949470177293 TiB
+  context: |
+    - 1 TB
+    - 2 TB
+    - 3 TB
+    - 4 TB
+    - 5 TB
+    - 6 TB
+    - 7 TB
+    - 8 TB
+    - 9 TB
+    - 10 TB
+  question: 'convert the following TB units to TiB'
+task_description: |
+    A skill to differenciate between KB, MB, GB, TB (SI (The
+    International System of Units) and their respective binary units KiB,
+    MiB, GiB, TiB (IEC binary (International
+    Electrotechnical Commission).
+    This a pretty common for data storage unit conversion.


### PR DESCRIPTION
The model is having trouble differentiating between SI (The International System of Units) and IEC binary (International Electrotechnical Commission).
For instance the model explains that 1 GB is equal to 1 GiB, which is false 1 GB is 0.9313 GiB.

Some error examples:

```
>>> please convert 1GB to GiB                                                                                                     [S][default]
╭─────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ────────────────────────────────────────────────────────────╮
│ Certainly! The symbol for Gibibytes, the binary prefix denoting 2^30 bytes, is Gibibyte (GiB). However, when people say "GiB," they often  │
│ mean Gigabytes (GB), which is the decimal prefix denoting 10^9 bytes. Therefore, if you want to convert 1 GB (Gigabyte) to GiB (Gibibyte), │
│ the conversion factor is approximately 1.074, making 1 GB equal to about 1.074 GiB.                                                        │
│                                                                                                                                            │
│ In summary, 1 GB is approximately equal to 1.074 GiB, but it's essential to clarify which unit you're referring to when using these terms, │
│ as they can have different meanings in various contexts.                                                                                   │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 30.476 seconds ─╯
```

Another one:

```
>>> please convert 1GB to GiB                                                                                                     [S][default]
╭─────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ────────────────────────────────────────────────────────────╮
│ The abbreviation "GiB" is often used interchangeably with "GB" in everyday conversation, but it is actually a more specific term that      │
│ stands for Giga-binary bytes (or Gigabinary). To convert 1GB (Giga-base 10 bytes) to GiB (Giga-binary bytes), we need to consider that 1   │
│ binary digit (bit) can represent one of two values (0 or 1). On the other hand, 1 decimal digit (base 10) can represent one of ten values  │
│ (0 to 9). Therefore, 1 decimal digit can store about 3.322 bits of information. Since 1 byte is equal to 8 bits, 1 decimal digit can store │
│ about 3.322 / 8 ≈ 0.4157 bytes of information.                                                                                             │
│                                                                                                                                            │
│ So, to convert 1GB (Giga-base 10 bytes) to GiB (Giga-binary bytes), we need to divide the value in bytes by the conversion factor of       │
│ 0.4157 bytes per decimal digit:                                                                                                            │
│                                                                                                                                            │
│ 1GB / 0.4157 bytes/decimal_digit ≈ 2.4049 GiB                                                                                              │
│                                                                                                                                            │
│ Therefore, 1GB is approximately equal to 2.4049 GiB.                                                                                       │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 50.207 seconds ─╯
```

Another one:

```
>>> please convert 1GB to GiB                                                                                                     [S][default]
╭─────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ────────────────────────────────────────────────────────────╮
│ In the previous response, I provided a more detailed explanation of the conversion factor between GB (Giga-base 10 bytes) and GiB          │
│ (Giga-binary bytes). However, the conversion factor used in the previous response is not entirely accurate, as it assumes that 1 decimal   │
│ digit can store exactly 3.322 bits of information. In reality, the conversion factor should be slightly different, as the relationship     │
│ between decimal digits and binary bits is not exactly linear.                                                                              │
│                                                                                                                                            │
│ To obtain a more accurate conversion factor, we can use the following formula:                                                             │
│                                                                                                                                            │
│ conversion_factor = (log2(10)) / log2(2) ≈ 3.3219                                                                                          │
│                                                                                                                                            │
│ Using this conversion factor, we can convert 1GB (Giga-base 10 bytes) to GiB (Giga-binary bytes) as follows:                               │
│                                                                                                                                            │
│ 1GB * conversion_factor ≈ 1GB * (3.3219 bytes/decimal_digit) ≈ 2.4002 GiB                                                                  │
│                                                                                                                                            │
│ Therefore, 1GB is approximately equal to 2.4002 GiB when using a more accurate conversion factor.                                          │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 44.037 seconds ─╯
```

One last one for fun:

```
>>> please convert 1GB to GiB                                                                                                     [S][default]
╭─────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ────────────────────────────────────────────────────────────╮
│ The prefixes used to measure data storage have been standardized by the International Electrotechnical Commission (IEC) and the Institute  │
│ of Electrical and Electronics Engineers (IEEE). The IEC uses the unit Gibibyte (GiB) for data storage, while the IEEE uses the unit        │
│ Gigabyte (GB) for digital information storage.                                                                                             │
│                                                                                                                                            │
│ To convert 1 GB (Gigabyte) to GiB (Gibibyte), we can use the following conversion factor: 1 GiB = 1024 MB, where 1 MB = 1000 KB.           │
│ Therefore, 1 GB is equal to 1024 / 1000 = 1.024 GiB. So, 1 GB is equal to approximately 1.024 GiB.                                         │
│                                                                                                                                            │
│ In summary, 1 GB is equal to approximately 1.024 GiB, when converting between the IEC and IEEE standards for digital information storage.  │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 37.782 seconds ─╯
```

If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- ...
- ...
- ...


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   ...
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  ...
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
