### PR TITLE
Teach lab about Beakerlib (shell one)

### DIFF
--- a/compositional_skills/writing/freeform/technical/template/beakerlib/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/template/beakerlib/qna.yaml
@@ -1,0 +1,38 @@
+---
+created_by: lukaszachy
+seed_examples:
+  - answer: |
+      #!/bin/bash
+      # vim: dict+=/usr/share/beakerlib/dictionary.vim cpt=.,w,b,u,t,i,k
+      . /usr/share/beakerlib/beakerlib.sh || exit 1
+
+      set -o pipefail
+
+      rlJournalStart
+        rlPhaseStartSetup
+          rlRun "tmp_dir=\$(mktemp -d)"
+          rlRun "pushd $tmp"
+        rlPhaseEnd
+
+        rlPhaseStartTest
+          rlRun -s "echo Hello World"
+          rlAssertGrep "Hello World" "$rlRun_LOG" "-F"
+        rlPhaseEnd
+
+        rlPhaseStartCleanup
+            rlRun "popd"
+            rlRun "rm -r $tmp" 0 "Remove tmp directory"
+        rlPhaseEnd
+      rlJournalEnd
+    question: Write skeleton for a test using Beakerlib framework
+  - answer: |
+      rlRun "rlWaitForSocket 80 -t 200"
+    question: |
+      Write Beakerlib command asserting that something listens on port 80
+      and wait up to 200 seconds if it wasn't listening from the very beginning.
+  - answer: |
+      rlRun "rlWatchdog \"rlRun \\\"sleep 20; echo command\\\" 0 \" 30"
+    question: |
+      Write Beakerlib command asserting exit code of the command as well
+      as that command finished in 30 seconds.
+task_description:


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

Lab knows how to write Beakerlib tests
- The skeleton common for most tests
- Use asserted watchdog
- Wait for port to open


**Input given at the prompt**

```
I want to write integration test using bash and beakerlib, how to start
```


**Response that was received**
```
  Beakerlib is a test automation framework written in Python that allows you to write integration tests in Bash or any other shell scripting           │
│ languages. To get started with integration testing using Bash and Beakerlib, consider the following steps:                                           │
│                                                                                                                                                      │
│ 1. **Install Beakerlib**: To install Beakerlib, follow the installation instructions provided in the official documentation:                         │
│ https://beaker-lib.readthedocs.io/en/latest/beakerlib-quickstart.html#installation                                                                   │
│                                                                                                                                                      │
│ 2. **Create a Test Directory**: Create a new directory for your integration tests, for example:                                                      │
│    ```                                                                                                                                               │
│    mkdir beaker_test                                                                                                                                 │
│    cd beaker_test                                                                                                                                    │
│    ```                                                                                                                                               │
│                                                                                                                                                      │
│ 3. **Create a Test File**: In your beaker_test directory, create a new Beakerlib test file named `test_myapp.sh`. This file will contain your        │
│ integration tests.                                                                                                                                   │
│                                                                                                                                                      │
│ 4. **Write Your First Integration Test**: In your `test_myapp.sh` file, add the following test case:                                                 │
│    ```bash                                                                                                                                           │
│    #!/bin/bash                                                                                                                                       │
│    # load the beakerlib framework                                                                                                                    │
│    . /usr/share/beakerlib/lib/beakerlib/beakerlib.bash                                                                                               │
│    # create a test case                                                                                                                              │
│    rspec_test "My first            
```


**Response that is now received instead**

I had troubles using Kaggle, just submitting the qna.yaml file for now.


**Contribution checklist**

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
