### PR TITLE
Add skill to find repeated elements in a list

### DIFF
--- a/compositional_skills/extraction/inference/quantitative/list_repetitions/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/list_repetitions/qna.yaml
@@ -1,0 +1,18 @@
+created_by: amoralej
+seed_examples:
+- answer: 'Upon examining the list, we find that element ndsa is repeated in that list.'
+  context: "abcd, ndsa, dcsa, fjseg, asdg, asd, h and ndsa"
+  question: 'Is there any repeated element in the following list?: '
+- answer: 'Upon examining the list, we find that there is no repeated element as each item is unique.'
+  context: "abcd, dcsa, fjseg, asdg, asd, h and ndsa ?"
+  question: 'Is there any repeated element in the following list?: '
+- answer: 'Upon examining the list, we find that there is no repeated element as each item is unique.'
+  context: "cant, vila, fslths, ckfg, ftras and x ?"
+  question: 'Is there any repeated element in the following list?: '
+- answer: 'Upon examining the list, we find that element vila is repeated in that list.'
+  context: "cant, vila, fslths, ckfg, ftras, vila and x ?"
+  question: 'Is there any repeated element in the following list?: '
+- answer: 'Upon examining the list, we find that elements vila and ftras are repeated in that list.'
+  context: "cant, vila, fslths, ckfg, ftras, vila, x and ftras"
+  question: 'Is there any repeated element in the following list?: '
+task_description: 'Find repeated elements in a list'


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

This idea of this contribution is to improve the LLM skill of detecting repeated elements in a list of arbitrary strings.

**Input given at the prompt :  case 1**

```
Is there any repeated element in the list: abcd, dcsa, fjseg, asdg, asd, h and ndsa ?
```

**Response that was received: case 1**

```
   Yes, there is a repeated element in the list: abcd, dcsa, fjseg, asdg, asd, h and ndsa? The repeated element is "asd," which appears twice in the list. 
```

**Input given at the prompt :  case 2**

Note I asked twice in the same list and response on 1st one is confusing the second

*** Input case 2 - 1:
```
Is there any repeated element in the list: abcd, dcsa, fjseg, asdg, h and ndsa ?
```

***Response that was received: case 2 - 1***

```
  To determine if there is a repeated element in the given list, we can either manually compare each element or use a programming language to check for duplicates. In this case, let's manually compare the elements:

1. abcd 
2. dcsa
3. fjseg
4. asdg
5. h
6. ndsa

Upon examining the list, we find that there is no repeated element as each item is unique. 

```
*** Input case 2 - 2:
```
Is there any repeated element in the list: abcd, ndsa, dcsa, fjseg, asdg, asd, h and ndsa ?
```

***Response that was received: case 2 - 2***

```
  After examining the list, we find that the order of elements does not matter when checking for duplicates. Therefore, we can conclude that the list::

1. abcd
2. ndsa
3. dcsa
4. fjseg
5. asdg
6. asd
7. h
8. ndsa

also does not contain any repeated elements.

```

**Response that is now received instead**

I dould not retrain my model

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] tested contribution with `lab generate`
- [ ] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
