### PR TITLE
Improve inclusive language by teaching about allowlist and denylist

### DIFF
--- a/compositional_skills/writing/grounded/inclusivity/qna.yaml
+++ b/compositional_skills/writing/grounded/inclusivity/qna.yaml
@@ -1,0 +1,24 @@
+created_by: nate-johnston
+seed_examples:
+- answer: |
+    These instructions describe how to modify sendmail's configuration
+    file to enable the dnsbl (DNS Denylist) feature to block incoming e-mail
+    from IP addresses that are listed on one or more denylists. These
+    particular denylists are checked by sendmail during the SMTP conversation,
+    avoiding the generation of the bounce messages that are generated (for
+    example) when SpamAssassin--called from procmail--consults DNS Denylists.
+    (The configuration of SpamAssassin to consult DNS Denylists is outside the
+    scope of this document.)
+  context: |
+    These instructions describe how to modify sendmail's configuration
+    file to enable the dnsbl (DNS Blacklist) feature to block incoming e-mail
+    from IP addresses that are listed on one or more blacklists. These
+    particular blacklists are checked by sendmail during the SMTP conversation,
+    avoiding the generation of the bounce messages that are generated (for
+    example) when SpamAssassin--called from procmail--consults DNS Blacklists.
+    (The configuration of SpamAssassin to consult DNS Blacklists is outside the
+    scope of this document.)
+  question: Use more inclusive language in the text.
+task_description: ''
+# attribution: text extracted on Mar 8 2024 from
+# https://weldon.whipple.org/sendmail/dnsbl.html


### PR DESCRIPTION
Improve processing inclusive language by expressing the preference for allowlist and denylist over whitelist and blacklist, respectively.

If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Improve processing inclusive language by expressing the preference for
  allowlist and denylist over whitelist and blacklist, respectively.


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
use more inclusive language in the following text: "in the access
map, then all e-mail with a sender address of <user@my.domain> gets
through, even if check_relay would reject it (e.g., based on the ho
stname or IP address). This allows spammers to get around DNS based
blacklist by faking the sender address. To avoid this problem you have
to use tagged entries:"
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
In the access map, any email with a sender address of <user@my.domain>
will be allowed to pass through, regardless of whether check_relay would
reject it based on factors such as hostname or IP address. This may
enable spammers to circumvent DNS-based blacklists by impersonating
sender addresses. To mitigate this issue, it is essential to implement
tagged entries to ensure proper email filtering and maintain security.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  Not applicable as I wasn't yet able to re-train the model.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] tested contribution with `lab generate`
- [ ] `lab generate` does not produce any warnings or errors
- [ ] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
