### PR TITLE
ci: Verify contents of qna.yaml files

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,12 +20,15 @@ on:
     branches:
       - main
     paths:
-      - 'compositional_skills/**/qna.yaml'
+      - compositional_skills/**/qna.yaml
+      - knowledge/**/qna.yaml
+
   pull_request:
     branches:
       - main
     paths:
-      - 'compositional_skills/**/qna.yaml'
+      - compositional_skills/**/qna.yaml
+      - knowledge/**/qna.yaml
 
 jobs:
   lint:
@@ -33,7 +36,43 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
-        
-      - name: "Run YAML linter"
+        with:
+          fetch-depth: 0
+
+      - name: "Find changed qna.yaml files"
+        id: changed-files
+        uses: tj-actions/changed-files@v42
+        with:
+          files: |
+            **/qna.yaml
+
+      - name: "Run YAML lint"
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}, yaml-files: ['qna.yaml']}" .
+          yamllint -d "{extends: relaxed, rules: {line-length: {max: 120}}}" ${{ steps.changed-files.outputs.all_changed_files }}
+
+      # use yq to verify YAML fields exist and generate a matchable log message with line number and error severity
+      # the added matcher .github/workflows/matchers/lint.json will parse those log messages to generate annotation
+      # the generated annotations are then applied in the GH PR Changed Files view under the changed line of code
+      - name: "Check qna.yaml file contents"
+        if: steps.changed-files.outputs.any_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          echo "::add-matcher::.github/workflows/matchers/lint.json"
+          ERR=0
+          error() { echo "ERROR: $file:$@" 1>&2; ERR=1; }
+          warn()  { echo "WARN:  $file:$@" 1>&2; }
+          echo
+          for file in ${CHANGED_FILES}; do
+            case $file in knowledge*)
+              error "1:1: We do not accept knowledge PRs at this time"
+            esac
+            yq '.created_by       | length > 0'     $file | grep -q false  &&  warn  "$(yq '.created_by|line'       $file):1: missing/empty 'created_by'"
+            yq '.task_description | length > 0'     $file | grep -q false  &&  warn  "$(yq '.task_description|line' $file):1: missing/empty 'task_description'"
+            yq '.seed_examples'                     $file | grep -q null   &&  error "$(yq '.seed_examples|line'    $file):1: missing 'seed_examples'"
+            yq '.seed_examples   | length >= 3'     $file | grep -q false  &&  warn  "$(yq '.seed_examples|line'    $file):1: less than 3 'seed_examples'"
+            yq '.seed_examples[] | has("question")' $file | grep -q false  &&  error "$(yq '.seed_examples|line'    $file):1: missing 'question's"
+            yq '.seed_examples[] | has("answer")'   $file | grep -q false  &&  error "$(yq '.seed_examples|line'    $file):1: missing 'answer's"
+          done
+          exit $ERR

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,7 +73,7 @@ jobs:
             yq '.seed_examples'                            $file | grep -q null  && error "$(yq '.seed_examples|line'    $file):1: missing 'seed_examples'"
             yq '.seed_examples   | length >= 3'            $file | grep -q false && warn  "$(yq '.seed_examples|line'    $file):1: less than 3 'seed_examples'"
             yq '.seed_examples[] | .question | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'question's"
-            yq '.seed_examples[] | .answer   | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'question's"
+            yq '.seed_examples[] | .answer   | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'answer's"
             if $( yq '.seed_examples[] | has("context")'   $file | grep -q true ); then
               yq '.seed_examples[] | .context| length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'context's"
             fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,11 +68,14 @@ jobs:
             case $file in knowledge*)
               error "1:1: We do not accept knowledge PRs at this time"
             esac
-            yq '.created_by       | length > 0'     $file | grep -q false  &&  warn  "$(yq '.created_by|line'       $file):1: missing/empty 'created_by'"
-            yq '.task_description | length > 0'     $file | grep -q false  &&  warn  "$(yq '.task_description|line' $file):1: missing/empty 'task_description'"
-            yq '.seed_examples'                     $file | grep -q null   &&  error "$(yq '.seed_examples|line'    $file):1: missing 'seed_examples'"
-            yq '.seed_examples   | length >= 3'     $file | grep -q false  &&  warn  "$(yq '.seed_examples|line'    $file):1: less than 3 'seed_examples'"
-            yq '.seed_examples[] | has("question")' $file | grep -q false  &&  error "$(yq '.seed_examples|line'    $file):1: missing 'question's"
-            yq '.seed_examples[] | has("answer")'   $file | grep -q false  &&  error "$(yq '.seed_examples|line'    $file):1: missing 'answer's"
+            yq '.created_by       | length > 0'            $file | grep -q false && warn  "$(yq '.created_by|line'       $file):1: missing/empty 'created_by'"
+            yq '.task_description | length > 0'            $file | grep -q false && warn  "$(yq '.task_description|line' $file):1: missing/empty 'task_description'"
+            yq '.seed_examples'                            $file | grep -q null  && error "$(yq '.seed_examples|line'    $file):1: missing 'seed_examples'"
+            yq '.seed_examples   | length >= 3'            $file | grep -q false && warn  "$(yq '.seed_examples|line'    $file):1: less than 3 'seed_examples'"
+            yq '.seed_examples[] | .question | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'question's"
+            yq '.seed_examples[] | .answer   | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'question's"
+            if $( yq '.seed_examples[] | has("context")'   $file | grep -q true ); then
+              yq '.seed_examples[] | .context| length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'context's"
+            fi
           done
           exit $ERR

--- a/.github/workflows/matchers/lint.json
+++ b/.github/workflows/matchers/lint.json
@@ -1,0 +1,30 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "lint-warning",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^WARN:\\s+(.+):(\\d+):(\\d+):\\s+(.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    },
+    {
+      "owner": "lint-error",
+      "severity": "error",
+      "pattern": [
+        {
+          "regexp": "^ERROR:\\s+(.+):(\\d+):(\\d+):\\s+(.+)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The current CI checks do a basic `yamllint` but don't actually verify the `qna.yaml` files contain the required contents

This PR updates the existing CI lint workflow:
- Only run the linter when `qna.yaml` file(s) were changed
- Add a step to identify only the `qna.yaml` file(s) changed in the PR
- Use `yq` to check specific fields inside the `qna.yaml` file(s)
- Generate a match-able log messages for missing/empty fields
- Use a [problem matcher](https://github.com/actions/toolkit/blob/main/docs/problem-matchers.md) to parse the generate error messages to annotate the Changed files in the PR
- Generate an error for knowledge contributions

Resolves #18

**Note:** 

The [intention][1] is to replace these basic checks using the the same code that is used by the CLI which is being worked in instruct-lab/cli#133 and instruct-lab/cli#205. It's not currently possible to run that CLI code in GH actions on the taxonomy repo.

[1]: https://github.com/instruct-lab/taxonomy/pull/39#discussion_r1511744968

---

**ILLUSTRATION**

This PR on my fork is showing the lint annotation aligned with changed lines of code in the **[Files changed](https://github.com/ckadner/taxonomy/pull/5/files#diff-7218ec3d210631a42a12e0a7d685f5a4a449e6b203b08132d4f3d6650d57f71f)** tab

<img width="471" alt="image" src="https://github.com/instruct-lab/taxonomy/assets/12246093/a21c0443-5293-42ae-a9ff-ba5d0a42f85c">


