### PR TITLE
Add skill to tell american football jokes

### DIFF
--- a/compositional_skills/writing/freeform/jokes/american_football/qna.yaml
+++ b/compositional_skills/writing/freeform/jokes/american_football/qna.yaml
@@ -1,0 +1,20 @@
+---
+created_by: larmbuster
+seed_examples:
+  - answer: |
+      What did the receiver say to the football?
+      
+      Catch you later!
+    question: Tell me an american football joke about receivers.
+  - answer: |
+      Why was Cinderella such a lousy football player?
+      
+      Because her coach was a pumpkin.
+    question: Tell me an american football joke about fairy tales.
+  - answer: |
+      What football player has very strong legs and builds houses?
+      
+      A carpunter
+    question: Tell me an american football joke about punters.
+task_description: |
+The american_football task enables the telling of funny american football jokes.

--- a/compositional_skills/writing/freeform/jokes/american_football/qna.yaml
+++ b/compositional_skills/writing/freeform/jokes/american_football/qna.yaml
@@ -17,4 +17,4 @@ seed_examples:
       A carpunter
     question: Tell me an american football joke about punters.
 task_description: |
-The american_football task enables the telling of funny american football jokes.
+  The american_football task enables the telling of funny american football jokes.

--- a/compositional_skills/writing/freeform/jokes/american_football/qna.yaml
+++ b/compositional_skills/writing/freeform/jokes/american_football/qna.yaml
@@ -1,4 +1,3 @@
----
 created_by: larmbuster
 seed_examples:
   - answer: |

--- a/compositional_skills/writing/freeform/jokes/american_football/qna.yaml
+++ b/compositional_skills/writing/freeform/jokes/american_football/qna.yaml
@@ -1,19 +1,20 @@
+---
 created_by: larmbuster
 seed_examples:
   - answer: |
       What did the receiver say to the football?
-      
+
       Catch you later!
     question: Tell me an american football joke about receivers.
   - answer: |
       Why was Cinderella such a lousy football player?
-      
+
       Because her coach was a pumpkin.
     question: Tell me an american football joke about fairy tales.
   - answer: |
       What football player has very strong legs and builds houses?
-      
+
       A carpunter
     question: Tell me an american football joke about punters.
 task_description: |
-  The american_football task enables the telling of funny american football jokes.
+  The american_football task improves the telling of american football jokes.


### PR DESCRIPTION
**Add skill to tell american football jokes**

- The current model is not good at telling american football jokes
- This skill helps the responses make more sense


**Input given at the prompt**

```
   Tell me a joke about american football
```


**Response that was received**

```
Why don't American football players go on vacation to France? 
Because they might get lost in the cheese shop!
```


**Response that is now received instead**

```
What is the name of the football player who likes to watch horror movies?
The player is Boo Jackson.
```

**Contribution checklist**

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)