### PR TITLE
Add a skill for determining if a word matches a regex

### DIFF
--- a/compositional_skills/extraction/inference/qualitative/regex/qna.yaml
+++ b/compositional_skills/extraction/inference/qualitative/regex/qna.yaml
@@ -1,0 +1,33 @@
+created_by: fjuma
+seed_examples:
+- answer: 'The word "bubble" matches the regular expression "b[aeiou]bble"\
+    \ because "bubble" starts with a "b", contains the letter "u" from the\
+    \ list "(a, e, i, o, u)" at the second position, and ends with "bble"'
+  context: 'The word is "bubble". The regular expression is "b[aeiou]bble"'
+  question: Determine if the given word matches the given regular expression.
+- answer: 'The word "whither" matches the regular expression "wh[ei]ther"\
+    \ because "whither" starts with "wh", contains the letter "i" from the\
+    \ list "(e, i)" at the third position, and ends with "ther"'
+  context: 'The word is "whither". The regular expression is "wh[ei]ther"'
+  question: Determine if the given word matches the given regular expression.
+- answer: 'The word "claimed" matches the regular expression "cla[im]med"\
+     \ because "claimed" starts with "cla", contains the letter "i" from the\
+     \ list "(i, m)" at the fourth position, and ends with "med"'
+  context: 'The word is "claimed". The regular expression is "cla[im]med"'
+  question: Determine if the given word matches the given regular expression.
+- answer: 'The word "quest" matches the regular expression "[qg]uest"\
+     \ because "quest" contains the letter "q" from the\
+     \ list "(q, g)" at the first position and ends with "uest"'
+  context: 'The word is "quest". The regular expression is "[qg]uest"'
+  question: Determine if the given word matches the given regular expression.
+- answer: 'The word "meat" matches the regular expression "mea[lt]"\
+     \ because "meat" starts with "mea" and ends with the letter "t" from the\
+     \ list "(l, t)"'
+  context: 'The word is "meat". The regular expression is "mea[lt]"'
+  question: Determine if the given word matches the given regular expression.
+- answer: 'The word "hobble" matches the regular expression "[wgcbhn]obble"\
+     \ because "hobble" starts with the letter "h" from the\
+     \ list "(w, g, c, b, h, n)" and ends with "obble"'
+  context: 'The word is "hobble". The regular expression is "[wgcbhn]obble"'
+  question: Determine if the given word matches the given regular expression.
+task_description: 'Determining if a given word matches the given regular expression'


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

- Add a skill for determining if the given word matches the given regular expression

**Input given at the prompt**

```
You will be given a word and a regular expression. Your job is to determine if the given
word matches the given regular expression. The word is 'bubble'. The regular expression
is 'b[aeiou]bble'.
```

**Response that was received**
```
The word 'bubble' does not match the regular expression 'b[aeiou]bble' because the letter 'e'
in 'bubble' does not match the pattern '[aeiou]'. The regular expression 'b[aeiou]bble' matches
any word that starts with 'b', contains any vowel (a, e, i, o, u) at the second position, and 
ends with 'bble'.     
```

**Response that is now received instead**

```
TBD, still trying to train
```

**Input given at the prompt**

```
You will be given a word and a regular expression. Your job is to determine if the given
word matches the given regular expression. The word is 'babble'. The regular expression
is 'b[aeiou]bble'.
```

**Response that was received**

```
The word 'babble' does not match the regular expression 'b[aeiou]bble' because the letter
'a' in 'babble' does not match the pattern '[aeiou]'. The regular expression 'b[aeiou]bble'
matches any word that starts with 'b', contains any vowel (a, e, i, o, u) at the second position,
and ends with 'bble'. 
```

**Response that is now received instead**

```
TBD, still trying to train
```
**Input given at the prompt**

```
Determine if the given word matches the given regular expression. The word is 'lost'. 
The regular expression is 'l[io]st'
```

**Response that was received**
```
The word 'lost' does not match the regular expression 'l[io]st' because there is no letter
'i' or 'o' in 'lost'. The regular expression 'l[io]st' matches any word that starts with 'l', 
contains either 'i' or  'o' at the second position, and ends with 'st'.  
```

**Response that is now received instead**

```
TBD, still trying to train
```

**Contribution checklist**

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
