### PR TITLE
Add skill to discussing how to parse Directory Server access logs wit…

### DIFF
--- a/compositional_skills/writing/freeform/technical/LDAP/logging/access_log/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/LDAP/logging/access_log/qna.yaml
@@ -1,0 +1,14 @@
+created_by: mreynolds389
+seed_examples:
+- answer: 'The 389 Directory Server access logs contain information
+    about client requests to the server.  The logging includes timestamps,
+    authentication information, client information, the LDAP operation 
+    request, and result of these requests.
+        
+    Since the 389 Directory Server log does not follow any logging standards 
+    the server ships with a tool called "/usr/bin/logconv.pl".  This tool
+    has a variety of options on what and how to display statistics about the 
+    access log. See the tool usage for more information about its options.
+  '
+  question: How to parse 389 Directory Server access logs
+task_description: ''


### PR DESCRIPTION
it works

If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

The skill describes a tool that will aprse REd Hat Directory Server/389 Directory Server access logs


**Input given at the prompt**

How to parse 389 directory server access log


**Response that was received**

To parse a 389 Directory Server access log, you can use tools such as the `ldapsearch` command-line tool or the `ldifparse` Python library to extract the entries    
from the log file and analyze the data. The 389 Directory Server access log is a text file that contains information about the requests that have been made to the   
server, including the time, the request type, the client IP address, and the result of the request.                                                                                                                                                                                                                                       
To parse the access log, you can use the `grep` command-line tool to extract the entries that contain specific keywords, such as `add`, `delete`, or `modify`, to    
 identify the entries that have been modified. Alternatively, you can use the `ldifparse` Python library to parse the access log and extract the entries, including   
 the time, the request type, the client IP address, and the result of the request.                                                                                    
                                                                                                                                                                    
 Once you have extracted the entries from the access log, you can analyze the data to identify trends, patterns, or anomalies in the data, such as unusual request   
 patterns, high-volume requests, or requests from suspicious IP addresses. You can also use the data to troubleshoot issues with the server, such as performance      
 issues, authentication issues, or authorization issues.                                                                                                              
                                                                                                                                                                      
To improve the security of your 389 Directory Server, you can implement access controls, such as authentication, authorization, and encryption, to protect the data  
 in the directory from unauthorized access or modification. You can also implement logging, monitoring, and alerting to detect and respond to security incidents,     
 such as intrusion attempts, data breaches, or other security events.  



**Response that is now received instead**

After "lab generate" I did **NOT** get the expected response:



To parse the 389 Directory Server access log, you can use the `tail` command with the `-f` (follow) option, which will monitor the log file for new entries in       
 real-time. This is useful if you want to view the log entries as they occur.                                                                                         
                                                                                                                                                                     │ 
Here's an example command:                                                                                                                                           
 ```bash                                                                                                                                                              
 tail -f /var/log/dirsrv/slapd-<instance_name>/access.log                                                                                                             
 ```                                                                                                                                                                  
 Replace `<instance_name>` with the actual name of your directory server instance.                                                                                    
                                                                                                                                                                     
 If you prefer to parse the log file offline, you can use the `awk` command to extract specific information from each line of the log file. Here's an example `awk`   │
 command that extracts the user, host, and time of each entry:                                                                                                        │
 ```bash                                                                                                                                                              
 awk '{print $5" "$6" "$10}' /var/log/dirserv/slapd-<instance_name>/access.log                                                                                        
 ```                                                                                                                                                                  
 This command prints the fifth, sixth, and tenth fields of each line, which correspond to the user, host, and time, respectively.                                     
                                                                                                                                                                      
 Keep in mind that the format of the log file may change in future versions of the 389 Directory Server, so it's a good idea to consult the documentation for the     
 latest information on the log file format.                    
```

**Contribution checklist**

- [x ] tested contribution with `lab generate`
- [x ] `lab generate` does not produce any warnings or errors
- [x ] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x ] the `qna.yaml` file was [linted](https://yamllint.com)
