### PR TITLE
docs: Add note on signoff to main README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,14 @@ Here's an animated graphic to show how it works:
 
 ![screencast-directory-naming](https://github.com/instruct-lab/taxonomy/assets/799683/2cb2b031-52f6-46de-bfd9-c4eae82ec9d3)
 
+**Note:** If you use the GitHub web UI to commit your `qna.yaml` file, make sure to add your sign-off in the commit message otherwise the PR check for [DCO](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) will fail
+
+Here is an example `Signed-off-by` line, which indicates that the submitter accepts the DCO:
+
+```
+Signed-off-by: John Doe <john.doe@example.com>
+```
+
 **TO BE CONTINUED**
 
 ### How should I contribute?

--- a/README.md
+++ b/README.md
@@ -557,6 +557,8 @@ Here is an example `Signed-off-by` line, which indicates that the submitter acce
 Signed-off-by: John Doe <john.doe@example.com>
 ```
 
+The Signed-off-by must be at the end of the commit message separated by a blank line from the body of the commit message. The name and email address must match those for your GitHub account. The DCO checks the name/email matches the author's.
+
 **TO BE CONTINUED**
 
 ### How should I contribute?


### PR DESCRIPTION
This is tripping up lots of people making changes in the GitHub web UI. Once a commit is done in the web UI without a sign-off, it is too late.

This is a quick addition. Could be worded better :-)
---

<img width="833" alt="image" src="https://github.com/instruct-lab/taxonomy/assets/12246093/fa07d29b-dea5-4041-bfc4-dc54bc63e29f">
