### PR TITLE
Add skill to provide IPv4 CIDR info to the user

### DIFF
--- a/compositional_skills/writing/freeform/ipv4/qna.yaml
+++ b/compositional_skills/writing/freeform/ipv4/qna.yaml
@@ -1,0 +1,17 @@
+created_by: LorenzoBianconi
+seed_examples:
+  - answer: "No. According to RFC1918 the Internet Assigned Numbers Authority
+    (IANA) has reserved the following three blocks of the IP address space
+    for private internets:
+        10.0.0.0        -   10.255.255.255  (10/8 prefix)
+        172.16.0.0      -   172.31.255.255  (172.16/12 prefix)
+        192.168.0.0     -   192.168.255.255 (192.168/16 prefix)"
+    question: Is 192.168.0.1 a routable IPv4 address on a public IP network?
+  - answer: "
+    253 since 192.168.0.0 is the network identifier while 192.168.0.255 is
+    reseved for broadcast."
+    question: How many usable IPv4 addresses do we have in 192.168.0.x/24 network?
+  - answer: "Yes. In RFC5771 the Internet Assigned Numbers Authority (IANA) has
+    reserved the IP range 224.0.0.0–239.255.255.255 for multicast traffic."
+    question: Is multicast supported in IPv4?
+task_description: 'Provide IPv4 CIDR information'


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- What you entered, replace "..." -->

```
This contribution is intended to provide some guidance about IPv4 CIDR
```

**Input given at the prompt**
```
 Is 192.168.0.1 a routable IPv4 address on a public IP network?
```

**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
 No, 192.168.0.1 is not a routable IPv4 address on a public IP network. This IP address is reserved for private networks, specifically for use within intranets and local networks. As a result, it is not assigned to any specific organization or individual on the public internet, and it does not have a unique identifier that can be globally recognized. Therefore, it is not considered a routable IP address on a public IP network.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
 (test still in progress. lab generate takes hours here and it often exits with timeout)
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] tested contribution with `lab generate`
- [ ] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
