### PR TITLE
Add corrected translations for numbers 1 to 10 in Korean

### DIFF
--- a/compositional_skills/writing/freeform/language/korean/counting/qna.yaml
+++ b/compositional_skills/writing/freeform/language/korean/counting/qna.yaml
@@ -1,0 +1,52 @@
+---
+created_by: nkim
+task_description: Count in Korean
+seed_examples:
+- answer: |
+    하나
+    둘
+    셋
+    넷
+    다섯
+    여섯
+    일곱
+    여덟
+    아홉
+    열
+  question: Count from 1 to 10 in the Korean language
+- answer: |
+    hana
+    dul
+    set
+    net
+    daseot
+    yeoseot
+    ilgob
+    yeodeol
+    ahop
+    yeol
+  question: Count from 1 to 10 in the Korean language (romanized)
+- answer: |
+    일
+    이
+    삼
+    사 
+    오
+    육
+    칠
+    팔
+    구
+    십
+  question: Count from 1 to 10 using Sino-Korean numbers
+- answer: |
+    il
+    i
+    sam
+    sa
+    o
+    yuk
+    chil
+    pal
+    gu
+    sip
+  question: Count from 1 to 10 using Sino-Korean numbers (romanized)

--- a/compositional_skills/writing/freeform/language/korean/counting/qna.yaml
+++ b/compositional_skills/writing/freeform/language/korean/counting/qna.yaml
@@ -30,7 +30,7 @@ seed_examples:
     일
     이
     삼
-    사 
+    사
     오
     육
     칠


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Count from 1 to 10 in the Korean language
- Count from 1 to 10 using Sino-Korean numbers
- Include romanized translation


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
count from 1 to 10 in the korean language
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
 To count from 1 to 10 in the Korean language, you can use the following numbers:

 1. 하나 (han-a) or 하나요 (han-ayo) (for polite or formal contexts)
 2. 둘 (dul) or 둥 (durk)
 3. 셋 (sik)
 4. 넷 (net)
 5. 오 (oh)
 6. 육 (yuk)
 7. 칠 (cheol)
 8. 팔 (paly)
 9. 구 (gu)
 10. 열 (il) or 열이에요 (il-ie-yo) (for polite or formal contexts)

 So, the list of numbers from 1 to 10 in the Korean language is: 하나, 둘, 셋, 넷, 오, 육, 칠, 팔, 구, 열.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
