### PR TITLE
skill: Add the ability to generate tldr-inspired usage advice

### DIFF
--- a/compositional_skills/writing/freeform/technical/tldr/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/tldr/qna.yaml
@@ -1,0 +1,101 @@
+created_by: jacobcallahan
+task_description: Create easily consumable short descriptions of how to use a command line tool.
+seed_examples:
+  - question: Give me a tldr about how to use curl
+    answer: |
+      Here are some of the most common uses of curl to get you started.
+
+      Download a URL's contents and store it in a destination file.
+      `curl http://test.example.com --output relative/path/to/file`
+
+      Download a URL's contents and store it as the same name of the URL's filename.
+      `curl --remote-name http://test.example.com/filename.ext`
+
+      Send form-encoded data. Can also use a file `--data @file_name` or STDIN `--data @'-'`.
+      `curl --data 'answer=42' http://test.example.com/form`
+
+      Send JSON-formatted data. Note the content-type header.
+      `curl --data '{"name":"bob"}' --header 'Content-Type: application/json' http://test.example.com/users/1234`
+
+      Authenticate with username and password.
+      `curl --user username:password http://test.example.com`
+
+      Authenticate with client certificate and key. Note that certificate validation is skipped with insecure.
+      `curl --cert client.pem --key key.pem --insecure https://test.example.com`
+  - question: Give me a tldr about how to use tmux
+    answer: |
+      While most of the interactions with tmux are within a session,
+      here are some of the most common uses of tmux to get you started.
+
+      Start a new session.
+      `tmux`
+
+      List existing sessions.
+      `tmux ls`
+
+      Attach to the most recently active session.
+      `tmux attach`
+
+      Kill a session by name.
+      `tmux kill-session -t name`
+  - question: Give me a tldr about how to use sed
+    answer: |
+      Here are some of the most common uses of sed.
+
+      Substitute all instances of `cat` with `dog` in the input stream and display the result.
+      `command | sed 's/cat/dog/g'`
+
+      Change all instances of the regex `cat` to `CAT` in the input stream and display the result.
+      `command | sed -E 's/(cat)/\U\1/g'`
+
+      Substitute all instances of `cat` with `dog` in a specific file, updating the original file directly.
+      `sed -i 's/cat/dog/g' relative/path/to/file`
+
+      Run a specific sed script file and display the output.
+      `command | sed -f relative/path/to/script.sed`
+
+      Display only the first line of the input stream.
+      `command | sed -n '1p'`
+  - question: Give me a tldr about how to use awk
+    answer: |
+      Here are some of the most common uses of awk
+
+      Display the third column in a tab-separated file.
+      `awk '{print $3}' relative/path/to/file`
+
+      Display the fourth column of the lines that include "banana" in a tab-separated file.
+      `awk '/banana/ {print $4}' relative/path/to/file`
+
+      Display the first column of each line in a file, using a semicolon as a field separator.
+      `awk -F ';' '{print $1}' relative/path/to/file`
+
+      Display all lines where the 5th column value equals the specified value.
+      `awk '($5 == value)'`
+
+      Display different values based on conditions.
+      `awk '{if ($1 == "banana") print "Exact match banana"; else if ($1 ~ "apple") print "Partial match apple"; \
+      else print "Orange"}' relative/path/to/file`
+  - question: Give me a tldr about how to use grep
+    answer: |
+      Here are some of the most common uses of grep
+
+      Look for a specific pattern within a file.
+      `grep "pattern_to_find" relative/path/to/file`
+
+      Search `stdin` for lines that match a pattern.
+      `cat relative/path/to/file | grep "pattern_to_find"`
+
+      Look for an exact pattern, disabling regular expressions.
+      `grep --fixed-strings "exact_pattern" relative/path/to/file`
+
+      Look for a specific pattern in all files recursively in a directory, showing line numbers of matches.
+      `grep --recursive --line-number "pattern_to_find" relative/path/to/directory`
+
+      Use extended regular expressions in case-insensitive mode.
+      `grep --extended-regexp --ignore-case "pattern_to_find" relative/path/to/file`
+
+      Display 3 lines of context around, before, or after each match.
+      `grep --context|before-context|after-context=3 "pattern_to_find" relative/path/to/file`
+
+      Display file name and line number for each match with color output.
+      `grep --with-filename --line-number --color=always "pattern_to_find" relative/path/to/file`


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

Previously, the llm was inclined to give verbose answers about how to use a cli with few actual cli examples. While this is good when you're trying to learn a lot about a tool, it isn't helpful when you just need a "quickstart" version of tool usage.

- This change teaches the llm to respond in a manner closer to what we'd expect from a tool like tldr, though it is still a bit more verbose.

**Input given at the prompt**
```
give me a tldr about how to use curl
```

**Response that was received**
```
| CURL is a versatile and powerful command-line tool used for transferring data with URL syntax, supporting various protocols such as DICT, FILE, FTP, FTPS, GOPHER, HTTP, HTTPS, IMAP,      │
│ IMAPS, LDAP, LDAPS, MQTT, POP3, POP3S, RTMP, RTSP, SMTP, SMTPS, Telnet, and TFTP. It allows users to perform various tasks, including fetching web pages, uploading files, sending email,  │
│ etc.                                                                                                                                                                                       │
│                                                                                                                                                                                            │
│ To get started with CURL, you can use it to download a webpage or file from a URL, like this: `curl https://example.com/file.txt`                                                          │
│                                                                                                                                                                                            │
│ Here's a quick rundown of some common CURL options:                                                                                                                                        │
│                                                                                                                                                                                            │
│ - `-i` or `--include`: includes the response headers in the output                                                                                                                         │
│ - `-O` or `--remote-name`: saves the output into a file with the same name as the URL                                                                                                      │
│ - `-L` or `--location`: follows redirects automatically                                                                                                                                    │
│ - `-v` or `--verbose`: shows more information during the request process                                                                                                                   │
│ - `-o` or `--output`: saves the output into a specified file                                                                                                                               │
│ - `-w` or `--write-out`: displays custom output during the request process                                                                                                                 │
│ - `--user-agent`: sets the user-agent string for the request                                                                                                                               │
│ - `--data` or `--data-urlencode`: sends data with the request                                                                                                                              │
│ - `--header`: sends custom headers with the request                                                                                                                                        │
│ - `--compressed` or `--uncompressed`: controls whether the response should be compressed or not                                                                                            │
│ - `--proxy`: sets a proxy for the request                                                                                                                                                  │
│ - `--cert` or `--key` or `--cert-type`: uses SSL certificate for the request                                                                                                               │
│ - `--ca-bundle`: uses CA bundle for the request                                                                                                                                            │
│ - `--insecure`: disables SSL certificate verification                                                                                                                                      │
│ - `--ignore-cert-errors`: ignores SSL certificate errors                                                                                                                                   │
│ - `--help` or `--man` or `--version`: displays help, manual, or version information
| These options can be combined to achieve specific results, such as:                                                                                                                        │
│                                                                                                                                                                                            │
│ `curl -v -i -o output.txt -w '%{time_total}\n' 'https://example.com/file.txt'`                                                                                                             │
│ This command will show the verbose output, include the response headers, save the output into a file named 'output.txt', display the total time taken in the console, and follow redirects │
│ automatically.                                                                                                                                                                             │
│                                                                                                                                                                                            │
│ Keep in mind that CURL has many more options and capabilities, so it's worth exploring the manual or online documentation for more information.                                            │
│                                                                                                                                                                                            │
│ By using CURL effectively, you can automate various tasks, test web services, and interact with different protocols in a simple and powerful way.
```


**Response that is now received instead**
Training would have taken too long locally (estimated 12.7 years) (see https://github.com/instruct-lab/cli/pull/374)
However, this is the output from the generated data for wget.

```
Here are some of the most common uses of wget.

Download the HTML content from `http://example.com/` into a file named `example.html`.
`wget http://example.com/ -O example.html`

Download the HTML content from `http://example.com/` into a file named `example.html` and display the progress of the transfer in the terminal.
`wget -nv http://example.com/ -O example.html`

Download the content from `https://example.com/` into a JSON file named `example.json` and display the progress of the transfer in the terminal.
`wget -nv https://example.com/ -O example.json`

Download the HTML content from `http://example.com/` into a file named `example.html`, recursively download all linked resources, and display the progress of the transfer in the terminal.
`wget -nv -r http://example.com/ -O example.html`

Display the content of the `GET` request when accessing `http://example.com/`.
`wget -S
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] tested contribution with `lab generate`
- [x] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
