### PR TITLE
Remove extra "i" in compositionIal typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ in terms of a taxonomy contribution:
 [...]
 ```
 
-#### Grounded compositionial skill: YAML example
+#### Grounded compositional skill: YAML example
 
 Remember that grounded compositional skills require additional context
 


### PR DESCRIPTION
Fixing a typo in Readme.md, removing an extra "i" in `Grounded compositionial`