### PR TITLE
Add skill to solve brainteaser question involving negations

### DIFF
--- a/compositional_skills/writing/freeform/brainteasers/qna.yaml
+++ b/compositional_skills/writing/freeform/brainteasers/qna.yaml
@@ -1,0 +1,16 @@
+---
+created_by: hemajv
+seed_examples:
+  - answer: |
+      The statement "I am not not not not not hungry" can be simplified as "I am
+      not hungry".
+
+      When you have multiple "not" negations, they effectively cancel out each
+      other. So "not not" becomes a positive affirmation. Hence, even number of
+      "nots" will cancel each other to become positive and odd number of "nots"
+      will become negative. Therefore, when you have 5 "nots" in the sentence it
+      leaves the sentence to ultimately become negative.
+    question: |
+      If I say "I am not not not not not hungry", do I ultimately want to eat or
+      not?
+task_description: ''


### PR DESCRIPTION

**Describe the contribution to the taxonomy**

Adding skill to answer a brainteaser question involving neagtions.


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   If I say "I am not not not not not hungry", do I ultimately want to eat or not?  
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  The statement "I am not not not not not hungry" is a form of double negative, which can create ambiguity in    │
meaning. In this case, the sentence could be interpreted as expressing a strong desire for food, as the triple │
negative is essentially equivalent to a positive statement. However, the actual meaning may depend on the      │
context, tone of voice, and other factors, so it is essential to consider the entire conversation or situation │
when interpreting such statements.  
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
 The statement "I am not not not not not hungry" can be simplified as "I am
 not hungry".

 When you have multiple "not" negations, they effectively cancel out each
 other. So "not not" becomes a positive affirmation. Hence, even number of
"nots" will cancel each other to become positive and odd number of "nots"
will become negative. Therefore, when you have 5 "nots" in the sentence it
leaves the sentence to ultimately become negative.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] tested contribution with `lab generate`
- [ ] `lab generate` does not produce any warnings or errors
- [x] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] the `qna.yaml` file was [linted](https://yamllint.com)
