### PR TITLE
ci: Lint require at least 3 seed examples

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -71,7 +71,7 @@ jobs:
             yq '.created_by       | length > 0'            $file | grep -q false && warn  "$(yq '.created_by|line'       $file):1: missing/empty 'created_by'"
             yq '.task_description | length > 0'            $file | grep -q false && warn  "$(yq '.task_description|line' $file):1: missing/empty 'task_description'"
             yq '.seed_examples'                            $file | grep -q null  && error "$(yq '.seed_examples|line'    $file):1: missing 'seed_examples'"
-            yq '.seed_examples   | length >= 3'            $file | grep -q false && warn  "$(yq '.seed_examples|line'    $file):1: less than 3 'seed_examples'"
+            yq '.seed_examples   | length >= 3'            $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: less than 3 'seed_examples'"
             yq '.seed_examples[] | .question | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'question's"
             yq '.seed_examples[] | .answer   | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'answer's"
             if $( yq '.seed_examples[] | has("context")'   $file | grep -q true ); then

--- a/README.md
+++ b/README.md
@@ -69,6 +69,13 @@ Skills require a much smaller volume of content to contribute. A skill
 contribution to the taxonomy tree can be just a few lines of YAML (its
 `qna.yaml` file - "qna" is short for "questions and answers") in its entirety:
 
+Each `qna.yaml` file is required to contain a minimum of three question-answer
+pairs. The `qna.yaml` format should include the following fields:
+
+- `seed_examples` (three or more examples of question and answer pairs)
+- `created_by` (your GitHub username)
+- `task_description` (an optional description of the knowledge).
+
 #### Freeform compositional skill: YAML example
 
 This example assumes the GitHub username `mairin`:
@@ -211,7 +218,7 @@ pairs. The `qna.yaml` format should include the following fields:
 
 - `seed_examples` (three or more examples sourced from the provided knowledge
   documents)
-- `created_by` (your name)
+- `created_by` (your GitHub username)
 - `task_description` (an optional description of the knowledge).
 
 #### Knowledge: yaml example


### PR DESCRIPTION
Changing the PR checks for taxonomy contributions to require at least 3 seed examples.

The taxonomy README says it requires three (3) seed examples for knowledge contributions:

> Each qna.yaml file is required to contain a minimum of three question-answer pairs. The qna.yaml format should include the following fields:
> - `seed_examples` (three or more examples sourced from the provided knowledge documents)
> - `created_by` (your name)
> - `task_description` (an optional description of the knowledge).

Should the same not be true for skills contributions? ... requiring at least 3 seed examples? 

