### PR TITLE
docs: Add YAML formatter links to README and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,7 +42,7 @@ following questionnaire with whatever information is applicable to your PR.
 
 <!-- Insert an x between the empty brackets: [ ] >> [x] -->
 
-- [ ] tested contribution with `lab generate`
-- [ ] `lab generate` does not produce any warnings or errors
-- [ ] all [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
-- [ ] the `qna.yaml` file was [linted](https://yamllint.com)
+- [ ] Contribution was tested with `lab generate`
+- [ ] No errors or warnings were produced by `lab generate`
+- [ ] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
+- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)

--- a/README.md
+++ b/README.md
@@ -384,6 +384,11 @@ tool. There is a very nice website you can use to do this:
 You can copy/paste your YAML into the box and click the "Go" button to have it
 analyse your YAML and make recommendations.
 
+Online tools like [prettified](https://onlineyamltools.com/prettify-yaml) and
+[yaml-validator](https://jsonformatter.org/yaml-validator) can automatically
+reformat your YAML to adhere to our `yamllint` PR checks, like breaking lines
+longer than 120 characters.
+
 ## Layout
 
 The taxonomy tree is organized in a cascading directory structure. At the end of


### PR DESCRIPTION
Update the PR template, adding a few more links to format the `qna.yaml` files such that our linter does not bark about it.

Specifically the line length seems to be reported by `yamllint` but not automatically enforced by https://yamllint.com

<img width="479" alt="image" src="https://github.com/instruct-lab/taxonomy/assets/12246093/87e57fab-0e73-4340-9e85-139f89501901">

@joesepi  -- I know this is a pet peeve of yours ;-)
