### PR TITLE
feat: allow to check if commit is following conventional commits

### DIFF
--- a/compositional_skills/extraction/inference/qualitative/version_control/conventional_commits/qna.yaml
+++ b/compositional_skills/extraction/inference/qualitative/version_control/conventional_commits/qna.yaml
@@ -1,0 +1,216 @@
+created_by: benoitf
+task_description: >
+  Checks if the commit message is following the Conventional Commits
+  specification.
+seed_examples:
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      yes it is following the Conventional Commits specification.
+
+      It is a new feature allowing to provide config object to extend other
+      configs.
+
+      It is a breaking change due to the BREAKING CHANGE: footer.
+    context: >
+      feat: allow provided config object to extend other configs
+
+
+      BREAKING CHANGE: `extends` key in config file is now used for extending
+      other config files
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      yes it is following the Conventional Commits specification.
+
+      It is a new feature that will allow to send an email to the customer when
+      a product is shipped.
+
+      It is a breaking change due to the ! after the type/scope.
+    context: |
+      feat!: send an email to the customer when a product is shipped
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      yes it is following the Conventional Commits specification.
+
+      It is a new feature for the api scope that will allow to send an email to
+      the customer when a product is shipped
+
+      It is a breaking change due to the ! after the type/scope.
+    context: |
+      feat(api)!: send an email to the customer when a product is shipped
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      yes it is following the Conventional Commits specification.
+
+      It is a revert commit introduced by "let us never again speak of the
+      noodle incident" and referencing the sha 676104e and a215868.
+    context: |
+      revert: let us never again speak of the noodle incident
+
+      Refs: 676104e, a215868
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: |
+      yes it is following the Conventional Commits specification.
+      It is a bug fix commit that is preventing racing of requests.
+    context: |
+      fix: prevent racing of requests
+
+      Introduce a request id and a reference to latest request. Dismiss
+      incoming responses other than from latest request.
+
+      Remove timeouts which were used to mitigate the racing issue but are
+      obsolete now.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      yes it is following the Conventional Commits specification.
+
+      It is a new feature allowing to provide config object to extend other
+      configs.
+    context: |
+      feat: allow provided config object to extend other configs
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      no, because there is no colon followed by a space after the noun and an
+      optional scope surrounded by parenthesis.
+    context: |
+      fix my bug
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      no, because the optional scope is not surrounded by parenthesis but by
+      square brackets.
+    context: |
+      fix[invalid]: my bug
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      no, because the optional scope is not surrounded by parenthesis but by
+      square brackets.
+    context: |
+      fix[invalid]: my bug
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      no, because the type needs to be a noun and an optional surrounded by
+      parenthesis followed by a colon and a space.
+
+      But here, the type 'fix my bug' is too long and include spaces.
+    context: |
+      fix my bug: strange error
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      no, because there is no newline between the first line describing the type
+      and description and then the body
+
+      optional body
+
+      The body MUST begin one blank line after the description.
+    context: |
+      feat: introduce something new
+      Introduce a new feature that will allow to do something new
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      no, because there is a missing noung suffixed by a space and a colon
+
+      To be compliant for a new feature, it should be "feat: introduce something
+      new"
+    context: |
+      introduce something new
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: |
+      yes it is a chore commit cleaning up some files.
+    context: |
+      chore: cleanup files
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: >
+      yes it is following the Conventional Commits specification.
+
+      There is a noun type followed by an optional scope surrounded by
+      parenthesis, a colon followed by a space and a description.
+
+      There is an optional body that begins one blank line after the
+      description.
+
+      There is an optional footer that begins one blank line after the body.
+    context: |
+      type(optional scope): description
+
+      optional_body
+
+      optional footer
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: >
+      Is that this commit message is following Conventional Commits
+      specification?
+    answer: |
+      yes it is a chore commit cleaning up some files for the api scope.
+    context: |
+      chore(api): cleanup files
+    attribution:
+      - source: self-authored
+        license: Apache-2.0


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Allow to check if a commit message is following conventional commits


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
is that the commit message "feat: improve the skills" is following conventional commits ?
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
No, the commit message "feat: improve the skills" is not following the Conventional Commits specification. The Conventional Commits specification
requires a more specific format, including a type (e.g., `feat`, `fix`, `docs`, etc.) followed by a colon, a short description, and a scope (if
applicable). For example, a valid Conventional Commit message would be: `fix(parser): correct parse error in invalid input`.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
 Certainly! I'm here to help. A conventional commit refers to a standardized format for commit messages that follows a specific structure to simplify the process of generating changelogs and release notes. The structure includes three main components: type, scope, and subject. The type can be one of the following:

* **build:** Changes related to your project's build configuration or dependencies
* **ci:** Changes to your project's Continuous Integration configuration files
* **docs:** Changes to your project's documentation
* **feat:** A new feature
* **fix:** A bug fix
* **perf:** A code change that improves performance
* **refactor:** A code change that neither fixes a bug nor adds a feature
* **style:** Changes that do not affect the functionality of the code, such as formatting, missing semicolons, and indentation
* **test:** Adding missing tests or correcting existing tests

The scope, in this case, can be omitted as it is not always required. The subject, "improve the skills," describes the change concisely and in the imperative mood.

Using a conventional commit format helps maintain consistency in your project's commit history, making it easier for other developers to understand the changes made in each commit. It also simplifies the process of generating changelogs and release notes, as the information can be easily extracted from the commit
messages.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
