### PR TITLE
RFC: WIP: add dynamic Cyrillic translit linguistic skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -496,6 +496,22 @@ Below is an illustrative directory structure to show this layout:
                 └── one_line
                     └── qna.yaml
 ```
+
+## Dynamic `qna.yaml` generation
+
+For some skills, it may make sense to instead generate `qna.yaml` files
+programmatically. In this case, instead of manually defining a `qna.yaml` file,
+you can provide a `Containerfile` that, once built, could be executed to
+produce the intended `qna.yaml` file.
+
+The interface of a dynamic `qna.yaml` generator is as follows:
+
+- The taxonomy file is a `Containerfile` (or `Dockerfile`).
+- The container should define a `CMD` command that, once executed, will put the
+  intended `qna.yaml` file under `/out/qna.yaml` location.
+- The CLI will then run the generator, then use the resulting `qna.yaml` file
+- as a seed input, as usual.
+
 ## Contribute knowledge and skills to the taxonomy!
 
 The ability to contribute to a large language model (LLM) has been difficult in no small part because it is difficult to get access to the necessary compute infrastructure.

--- a/compositional_skills/extraction/linguistic/translit/cyrillic/Dockerfile
+++ b/compositional_skills/extraction/linguistic/translit/cyrillic/Dockerfile
@@ -1,0 +1,11 @@
+FROM python
+
+RUN apt-get update
+RUN apt-get install -y aspell-ru aspell-uk
+
+RUN pip install pyyaml
+RUN pip install cyrtranslit
+
+COPY . /app
+
+CMD ["/app/run"]

--- a/compositional_skills/extraction/linguistic/translit/cyrillic/dict
+++ b/compositional_skills/extraction/linguistic/translit/cyrillic/dict
@@ -1,0 +1,3 @@
+#!/bin/sh
+lang=$1
+aspell -d $lang dump master | aspell -l $lang expand | sed 's/ /\n/g'

--- a/compositional_skills/extraction/linguistic/translit/cyrillic/run
+++ b/compositional_skills/extraction/linguistic/translit/cyrillic/run
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+
+import itertools
+import os
+import random
+
+import yaml
+from cyrtranslit import mapping
+
+
+_LANGUAGES = {
+    'ru': 'Russian',
+    'ua': 'Ukrainian',
+}
+_LAN_TO_ASPELL_LANG = {
+    'ua': 'uk',
+}
+_MAX_WORDS_PER_LANG = 10
+_DICT_CMD = '/app/dict'
+
+
+def lang_name(lang):
+    return _LANGUAGES[lang]
+
+
+def join_letters(word):
+    letters = list(word)
+    return ', '.join(letters[:-1]) + ', and ' + letters[-1]
+
+
+def mapping_snippet(word, latin_letters):
+    mapping = zip(word, latin_letters)
+
+    snippet = ''
+    for cyrillic, latin in mapping:
+        snippet += f'- {cyrillic} = {latin}\n'
+    return snippet
+
+
+# todo: consider adjusting qna pair wording a bit to increase variability?
+def get_answer(lang, word, latin_letters):
+    return f'''
+In {lang_name(lang)}, the Cyrillic characters {join_letters(word)} can be
+translated to their corresponding Latin (or Roman) equivalents using the
+following transliteration scheme:
+
+{mapping_snippet(word, latin_letters)}
+Applying this transliteration scheme to the given Cyrillic sequence "{word}"
+results in the following Latin sequence: "{"".join(latin_letters)}".
+'''
+
+
+def tolatin(lang, word):
+    mapping_ = mapping.TRANSLIT_DICT[lang]["tolatin"]
+    return [mapping_.get(c, c) for c in word]
+
+
+def get_transliteration_scheme(lang):
+    return ", ".join(
+        f"{cyr} = {lat}"
+        for cyr, lat in mapping.TRANSLIT_DICT[lang]["tolatin"].items()
+    )
+
+
+def get_seed_example(lang, word):
+    return {
+        "answer": get_answer(lang, word, tolatin(lang, word)),
+        "context": word,
+        "question": f"Transform {lang_name(lang)} word into Latin letters.",
+        "prompt": (
+            f"8. Transliteration scheme is: "
+            f"{get_transliteration_scheme(lang)}\n"
+        ),
+    }
+
+
+def get_aspell_lang(lang):
+    return _LAN_TO_ASPELL_LANG.get(lang, lang)
+
+
+def get_words(lang):
+    cmd = f'{_DICT_CMD} {get_aspell_lang(lang)}'
+    words = list(os.popen(cmd))
+    random.shuffle(words)
+    for word in words:
+        yield word.strip()
+
+
+def main():
+    qna = {
+        'created_by': 'booxter',
+        'seed_examples': [],
+        'task_description': (
+            'Transliterating words from Cyrillic to Latin script.'
+        )
+    }
+
+    for lang in _LANGUAGES:
+        for word in itertools.islice(get_words(lang), _MAX_WORDS_PER_LANG):
+            qna["seed_examples"].append(get_seed_example(lang, word))
+
+    with open('/out/qna.yaml', 'w') as f:
+        yaml.dump(qna, f, allow_unicode=True, default_style="|")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is an attempt to add support for a Cyrillic-to-Latin transliteration skill that would also be language aware.

This is not validated and not working well with the default prompt defined in cli repo. (The prompt produces new instructions that are not retaining the transliteration scheme.)

Whether we need to use a model to generate variations of the generated instructions is itself a topic for exploration. (Perhaps we could live with feeding the seed samples generated by the skill directly into fine tuning.) But if so, additional changes may be required on `cli` side to e.g. allow to use modified (or completely new?) prompts if needed for a particular skill.

This is work-in-progress and is posted as a discussion starter.

---

***I'm omitting the section below, for now, because this PR is posted for discussion and not merge. If the dynamic generation approach is deemed useful in general, and if it's useful for this particular task, I will update the section then.***

If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.

**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- ...
- ...
- ...


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   ...
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  ...
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] Contribution was tested with `lab generate`
- [ ] No errors or warnings were produced by `lab generate`
- [ ] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
