### PR TITLE
Skill : how to migrate from will be soon expired CA to new CA in PKI

### DIFF
--- a/compositional_skills/writing/freeform/technical/network/juniper/pki/autovpn/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/network/juniper/pki/autovpn/qna.yaml
@@ -1,0 +1,13 @@
+---
+created_by: donaldxpark
+task_description: how to migrate from will be soon expired CA to new CA in PKI
+seed_examples:
+  - answer: |
+      it is called dual certificates support. you will need new CA certificates and the old CA certificates for the two headends (physically or logically) respetively, and remove the old CA certificates after new CA certificates up and running.
+    question: What is the best methodology for seamlessly migrating Juniper AutoVPN on SRX from one Certificate Authority (CA) to another CA in PKI environments
+  - answer: |
+      it is called dual certificates support. you will need new CA certificates and the old CA certificates for the two headends (physically or logically) respetively, and remove the old CA certificates after new CA certificates up and running.
+    question: what is the approach for the seamlessly migration of Juniper AutoVPN on SRX expired CA in PKI
+  - answer: |
+      it is called dual certificates support. you will need new CA certificates and the old CA certificates for the two headends (pysically or logically)  respetively, and remove the old CA certificates after new CA certificates up and running.
+    question: how we can seamlessly migrate of Juniper AutoVPN on SRX from will be soon expired CA to new CA in PKI


### PR DESCRIPTION
how to migrate from will be soon expired CA to new CA in PKI

If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- correct guidance for how to migrate from will be soon expired CA to new CA in PKI


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   how we can seamlessly migrate of Juniper AutoVPN on SRX from will be soon expired CA to new CA in PKI
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  Migrating from a soon-to-be-expired CA to a new CA in Public Key Infrastructure (PKI) environments, specifically when managing Juniper AutoVPN on SRX, can be accomplished using one of two approaches: certificate revocation or cross-signing certificates. Each method has its advantages and use cases, so the choice depends on your specific requirements and constraints.     
  1. **Certificate Revocation:** This approach involves revoking the certificate of the soon-to-be-expired CA and distributing the new certificate to all devices in the network. The main advantage of this method is its simplicity, as it only requires updating the certificate on the new CA and distributing it to the devices. However, it does involve some downtime during the revocation period, as devices may experience connection issues until they receive the new certificate.  
  To perform a certificate revocation migration:                                                                                                                                                                                                             - Revoke the certificate of the soon-to-be-expired CA.                           
  - Distribute the new certificate to all devices in the network.                                                                                                                                                                                    
  - Update the certificate on the new CA.                                                                                                                                                                                                            
  - Wait for all devices to receive the new certificate before revoking the old one.                                                                                                                                                                 
  - Revoke the old certificate. 
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  The approach for the seamlessly migration of Juniper AutoVPN on SRX from will be soon expired CA to new CA in PKI environments involves using dual certificates support. This means having both the new CA and the old CA certificates installed on the SRX device during the migration period, allowing for smooth transition between the two certificate authorities without affecting the VPN connections.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
