### PR TITLE
Add original SoMI sword insults

### DIFF
--- a/compositional_skills/writing/freeform/games/videogames/qna.yaml
+++ b/compositional_skills/writing/freeform/games/videogames/qna.yaml
@@ -1,0 +1,35 @@
+created_by: aesteve-rh
+seed_examples:
+  - answer: How appropriate. You fight like a cow!
+    question: You fight like a dairy Farmer!
+  - answer: 'And I''ve got a little TIP for you, get the POINT?'
+    question: 'This is the END for you, you gutter crawling cur!'
+  - answer: I'm glad to hear you attended your family reunion!
+    question: I've spoken with apes more polite than you!
+  - answer: First you'd better stop waving it like a feather duster.
+    question: Soon you'll be wearing my sword like a shish kebab!
+  - answer: Even BEFORE they smell your breath?
+    question: People fall at my feet when they see me coming!
+  - answer: Your hemorrhoids are flaring up again eh?
+    question: I'm not going to take your insolence sitting down!
+  - answer: He must have taught you everything you know.
+    question: I once owned a dog that was smarter than you.
+  - answer: You run THAT fast?
+    question: Nobody's ever drawn blood from me and nobody ever will.
+  - answer: Why? Did you want to borrow one?
+    question: Have you stopped wearing diapers yet?
+  - answer: 'Yes, there are. You just never learned them.'
+    question: There are no words for how disgusting you are.
+  - answer: You make me think somebody already did.
+    question: You make me want to puke.
+  - answer: 'So you got that job as janitor, after all.'
+    question: My handkerchief will wipe up your blood!
+  - answer: I hope now you've learned to stop picking your nose.
+    question: I got this scar on my face during a mighty struggle!
+  - answer: Too bad no one's ever heard of YOU at all.
+    question: I've heard you are a contemptible sneak.
+  - answer: I'd be in real trouble if you ever used them.
+    question: 'You''re no match for my brains, you poor fool.'
+  - answer: I wanted to make sure you'd feel comfortable with me.
+    question: You have the manners of a beggar.
+task_description: All 16 original Sword Fighting insults from  The Secret of Monkey Island


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Add all 16 original Sword Fighting insults from The Secret of Monkey Island
- While the chat recognizes it coming from Monkey Island, his explanation and quotes make no sense and look completely made up.
- The bot could answer as in "This is a quote from The Secret of Monkey Island Sword Fighting game. To win this exchange, the correct answer is: ...", but I thought engaging directly in the fight and respond with the corresponding comeback is funnier.
-  I could not train the model as I do not have a mac, but `lab generate` finally finished without errors:
```
INFO 2024-03-12 09:52:36,352 generate_data.py:373 Generation took 69332.17s
104it [19:15:32, 666.66s/it]
```

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   People fall at my feet when they see me coming!
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  This is a quote from "Monkey Island 2: LeChuck's Revenge." It is spoken by LeChuck, the primary antagonist, when he is first introduced in the game. The
  full dialogue goes as follows:

  LeChuck: "People fall at my feet when they see me coming!"
  Guybrush: "Oh, I don't think so, LeChuck!"
  LeChuck: "Oh yes, I do!"

 This quote showcases LeChuck's arrogance and confidence, as well as his belief in his own invincibility. The quote also highlights the contrast between
  LeChuck and Guybrush, as Guybrush is a relatively ordinary man who is trying to make his way in the world, while LeChuck is a powerful and intimidating
  force who is determined to crush anyone who stands in his way. The quote also serves to set the stage for the intense rivalry between the two characters
  that will play out throughout the game.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  Even BEFORE they smell your breath?
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
