### PR TITLE
Add skill for yes/no answers

### DIFF
--- a/compositional_skills/writing/freeform/yes_no_questions/qna.yaml
+++ b/compositional_skills/writing/freeform/yes_no_questions/qna.yaml
@@ -1,0 +1,11 @@
+created_by: luis5tb
+seed_examples:
+- answer: 'Yes'
+  question: Do you know Albert Einstein? Only answer yes or no
+- answer: 'Yes'
+  question: Is 1 + 2 = 3? Only answer yes or no
+- answer: 'No'
+  question: Is 1 + 2 = 4? Only answer yes or no
+- answer: 'No'
+  question: Do you have access to real time information? Only answer yes or no
+task_description: 'Answer questions with yes or no'


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

- Add the ability to response questions with yes/no answers

**Input given at the prompt**

```
   Is 1 + 2 = 4? Only answer "yes" or "no" 
```

**Response that was received**

```
  No, based on the basic arithmetic operation of addition, 1 + 2 equals 3, not 4
```


**Response that is now received instead**

```
  To Be Tested
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
