### PR TITLE
Add skill to generate daily notes with time-blocks

### DIFF
--- a/compositional_skills/writing/freeform/daily_notes/qna.yaml
+++ b/compositional_skills/writing/freeform/daily_notes/qna.yaml
@@ -1,0 +1,46 @@
+---
+created_by: gthiemonge
+seed_examples:
+  - question: |
+      Generate a time-block template with checkboxes for today, I want to do
+      some exercises in the morning and have lunch at 1pm, I need to take the
+      kids back from school at 4pm.
+    answer: |
+      - [ ] 7:00 - 8:00 Morning exercises
+      - [ ] 8:00 - 9:00 Shower and Breakfast
+      - [ ] 9:00 - 13:00 Work
+      - [ ] 13:00 - 14:00 Lunch
+      - [ ] 14:00 - 16:00 Work
+      - [ ] 16:00 - 17:00 Kids
+  - question: |
+      Generate a Template in Markdown for my daily notes of January 17th 2024,
+      including the list of completed tasks and things to do.
+    answer: |
+      January 17th 2024
+
+      # Notes
+      - [My notes]
+
+      # Completed tasks
+      - [First completed task]
+
+      # Planning
+      -
+  - question: |
+      Generate a Template in Mardown with my TODO list, remind me to call Bob,
+      and add it to the time-block section at 2pm. I also have a Customer
+      meeting at 10am.
+    answer: |
+      [Date]
+
+      # Todo
+      - Call Bob
+
+      # Planning
+      - [ ] 8:00 - 8:30 Breakfast
+      - [ ] 8:30 - 10:00 Work
+      - [ ] 10:00 - 11:00 Customer meeting
+      - [ ] 11:00 - 13:00 Work
+      - [ ] 13:00 - 14:00 Lunch
+      - [ ] 14:00 - 14:30 Call Bob
+      - [ ] 14:30 - 18:00 Work


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

- Add the ability to generate templates for daily notes (including time-blocking section)


**Input given at the prompt**

- generate an agenda for my day with time blocks, I want to do some sport in the morning and have lunch at 1pm


**Response that was received**

```
I'm happy to help you create a schedule for your day! Here's a suggested agenda:

7:00 – 8:00: Morning exercise (e.g., running, yoga, or weightlifting)
8:00 – 9:00: Shower and breakfast
9:00 – 12:00: Work or study
12:00 – 13:00: Lunch break
13:00 – 17:00: Work or study
17:00 – 18:00: Dinner and relaxation time
18:00 – 20:00: Free time or hobbies (e.g., reading, watching TV, or playing video games)

This schedule includes time blocks for exercise, breakfast, lunch, work or study, dinner, and relaxation time, as well as free time for hobbies or personal activities. The schedule is flexible and can be adjusted to fit your specific needs and preferences, so feel free to modify it as needed. The important thing is to make sure that you have enough time for exercise, meals, and work or study, as well as time for relaxation and free time to enjoy your hobbies and interests.
```


**Response that is now received instead**

```
7:00 - 8:00: Morning exercise
8:00 - 8:30: Shower and Breakfast
8:30 - 13:00: Work
13:00 - 14:00: Lunch
14:00 - 18:00: Work
18:00 - 19:00: Dinner
19:00 - 21:00: Free time
21:00 - 22:00: Preparing next day

[...]

8:00 - 9:00: Morning exercise
9:00 - 10:00: Shower and Breakfast

[...]

13:00 - 14:00: Lunch
```

**Contribution checklist**


- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
