### PR TITLE
Add a skill to try to improve ROT13 generation

### DIFF
--- a/compositional_skills/writing/grounded/editing/rot13/qna.yaml
+++ b/compositional_skills/writing/grounded/editing/rot13/qna.yaml
@@ -1,0 +1,133 @@
+# This task attempts to teach how to apply ROT13 to a text.
+# ROT13 is a simple substitution cipher that involves replacing each letter
+# by the one 13 positions ahead in the alphabet.
+---
+created_by: codificat
+seed_examples:
+  - answer: "Gur dhvpx oebja sbk whzcf bire gur ynml qbt"
+    context: |
+      ROT13 (or rot13, Rot13 or ROT-13) is a simple letter substitution cipher
+      that replaces a letter with the 13th letter after it in the Latin
+      alphabet.
+
+      Applying ROT13 to a text fragment requires examining its alphabetic
+      characters and replacing each one by the letter 13 places further along in
+      the alphabet, wrapping back to the beginning if necessary. A becomes N, B
+      becomes O, and so on up to M, which becomes Z, then the sequence continues
+      at the beginning of the alphabet: N becomes A, O becomes B, and so on to
+      Z, which becomes M.
+
+      Therefore, the letters are mapped as follows: A->N N->A B->O O->B C->P
+      P->C D->Q Q->D E->R R->E F->S S->F G->T T->G H->U U->H I->V V->I J->W W->J
+      K->X X->K L->Y Y->L M->Z Z->M
+
+      Only those letters which occur in the English alphabet are affected;
+      numbers, symbols, punctuation, whitespace, and all other characters are
+      left unchanged.
+
+      For example, the text "Sphinx of black quartz, judge my vow." becomes
+      "Fcuvak bs oynpx dhnegm, whqtr zl ibj." when ROT13 is applied.
+    question: |
+      ROT13 the following text: "The quick brown fox jumps over the lazy dog"
+  - answer: "Gur gbxravmre jvyy unhag lbh!"
+    context: |
+      ROT13 (or rot13, Rot13 or ROT-13) is a simple letter substitution cipher
+      that replaces a letter with the 13th letter after it in the Latin
+      alphabet.
+
+      Applying ROT13 to a text fragment requires examining its alphabetic
+      characters and replacing each one by the letter 13 places further along in
+      the alphabet, wrapping back to the beginning if necessary. A becomes N, B
+      becomes O, and so on up to M, which becomes Z, then the sequence continues
+      at the beginning of the alphabet: N becomes A, O becomes B, and so on to
+      Z, which becomes M.
+
+      Therefore, the letters are mapped as follows: A->N N->A B->O O->B C->P
+      P->C D->Q Q->D E->R R->E F->S S->F G->T T->G H->U U->H I->V V->I J->W W->J
+      K->X X->K L->Y Y->L M->Z Z->M
+
+      Only those letters which occur in the English alphabet are affected;
+      numbers, symbols, punctuation, whitespace, and all other characters are
+      left unchanged.
+
+      For example, the text "Sphinx of black quartz, judge my vow." becomes
+      "Fcuvak bs oynpx dhnegm, whqtr zl ibj." when ROT13 is applied.
+    question: |
+      rot13 this sentence: "The tokenizer will haunt you!"
+  - answer: "Tbbq zbeavat, zl sevraq."
+    context: |
+      ROT13 (or rot13, Rot13 or ROT-13) is a simple letter substitution cipher
+      that replaces a letter with the 13th letter after it in the Latin
+      alphabet.
+
+      Applying ROT13 to a text fragment requires examining its alphabetic
+      characters and replacing each one by the letter 13 places further along in
+      the alphabet, wrapping back to the beginning if necessary. A becomes N, B
+      becomes O, and so on up to M, which becomes Z, then the sequence continues
+      at the beginning of the alphabet: N becomes A, O becomes B, and so on to
+      Z, which becomes M.
+
+      Therefore, the letters are mapped as follows: A->N N->A B->O O->B C->P
+      P->C D->Q Q->D E->R R->E F->S S->F G->T T->G H->U U->H I->V V->I J->W W->J
+      K->X X->K L->Y Y->L M->Z Z->M
+
+      Only those letters which occur in the English alphabet are affected;
+      numbers, symbols, punctuation, whitespace, and all other characters are
+      left unchanged.
+
+      For example, the text "Sphinx of black quartz, judge my vow." becomes
+      "Fcuvak bs oynpx dhnegm, whqtr zl ibj." when ROT13 is applied.
+    question: |
+      Rot13 this text: "Good morning, my friend."
+  - answer: "Good morning, my friend."
+    context: |
+      ROT13 (or rot13, Rot13 or ROT-13) is a simple letter substitution cipher
+      that replaces a letter with the 13th letter after it in the Latin
+      alphabet.
+
+      Applying ROT13 to a text fragment requires examining its alphabetic
+      characters and replacing each one by the letter 13 places further along in
+      the alphabet, wrapping back to the beginning if necessary. A becomes N, B
+      becomes O, and so on up to M, which becomes Z, then the sequence continues
+      at the beginning of the alphabet: N becomes A, O becomes B, and so on to
+      Z, which becomes M.
+
+      Therefore, the letters are mapped as follows: A->N N->A B->O O->B C->P
+      P->C D->Q Q->D E->R R->E F->S S->F G->T T->G H->U U->H I->V V->I J->W W->J
+      K->X X->K L->Y Y->L M->Z Z->M
+
+      Only those letters which occur in the English alphabet are affected;
+      numbers, symbols, punctuation, whitespace, and all other characters are
+      left unchanged.
+
+      For example, the text "Sphinx of black quartz, judge my vow." becomes
+      "Fcuvak bs oynpx dhnegm, whqtr zl ibj." when ROT13 is applied.
+    question: |
+      What is the ROT13 of "Tbbq zbeavat, zl sevraq."?
+  - answer: "Jub jnagf gb yvir sberire, jura ybir zhfg qvr?"
+    context: |
+      ROT13 (or rot13, Rot13 or ROT-13) is a simple letter substitution cipher
+      that replaces a letter with the 13th letter after it in the Latin
+      alphabet.
+
+      Applying ROT13 to a text fragment requires examining its alphabetic
+      characters and replacing each one by the letter 13 places further along in
+      the alphabet, wrapping back to the beginning if necessary. A becomes N, B
+      becomes O, and so on up to M, which becomes Z, then the sequence continues
+      at the beginning of the alphabet: N becomes A, O becomes B, and so on to
+      Z, which becomes M.
+
+      Therefore, the letters are mapped as follows: A->N N->A B->O O->B C->P
+      P->C D->Q Q->D E->R R->E F->S S->F G->T T->G H->U U->H I->V V->I J->W W->J
+      K->X X->K L->Y Y->L M->Z Z->M
+
+      Only those letters which occur in the English alphabet are affected;
+      numbers, symbols, punctuation, whitespace, and all other characters are
+      left unchanged.
+
+      For example, the text "Sphinx of black quartz, judge my vow." becomes
+      "Fcuvak bs oynpx dhnegm, whqtr zl ibj." when ROT13 is applied.
+    question: |
+      Apply rot13 to: "Who wants to live forever, when love must die?"
+task_description: |
+  The rot13 skill enables to encode text with ROT13


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

This adds a grounded compositional editing skill to teach ROT13 to the model.

However, most current models are not capable of actually understanding and applying these instructions. Therefore, synthetic training sets generated for this skill are likely to be inaccurate.

At this time, this skill can be more useful as a benchmark / test for the process itself than as an actual skill.

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
rot13 this text: "Good morning, my friend!"
```

**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
The rot13'd text is "Grfgfher, zrffntr!"
```

Note that the generated rot13 text is incorrect, it corresponds to the text *"Testsure, message!"*.

**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

*TBD* as I am not able to fine tune a model with this skill.

But here is some generated content from the skill, from `lab generate` with the `merlinite-7b-Q4_K_M` model:

```json
[
    {
        "instruction": "Translate this sentence into English using rot13: \"Nyfb yvar vf nyfb!\"",
        "input": "",
        "output": "You are correct!"
    },
    {
        "instruction": "Explain what rot13 is and how it works.",
        "input": "",
        "output": "ROT13 is a simple letter substitution cipher that replaces a letter with the 13th letter after it in the Latin alphabet. To apply ROT13 to text, each alphabetic character in the text is replaced by the character that is 13 places further along in the alphabet, wrapping back to the beginning if necessary. For example, the letter A is replaced with N, B is replaced with O, and so on up to M, which is replaced with Z, and then the sequence continues at the beginning of the alphabet: N is replaced with A, O is replaced with B, and so on to Z, which is replaced with M. The letters that occur in the English alphabet are affected, while numbers, symbols, punctuation, whitespace, and all other characters are left unchanged. This cipher can be used for both encryption and decryption, as the same substitution pattern is used in both cases."
    },
    {
        "instruction": "Implement ROT13 on the phrase \"This is my first test!\"",
        "input": "ROT13 (or rot13, Rot13 or ROT-13) is a simple letter substitution cipher\nthat replaces a letter with the 13th letter after it in the Latin\nalphabet.\n\nApplying ROT13 to a text fragment requires examining its alphabetic\ncharacters and replacing each one by the letter 13 places further along in\nthe alphabet, wrapping back to the beginning if necessary. A becomes N, B\nbecomes O, and so on up to M, which becomes Z, then the sequence continues\nat the beginning of the alphabet: N becomes A, O becomes B, and so on to\nZ, which becomes M.\n\nTherefore, the letters are mapped as follows: A->N N->A B->O O->B C->P\nP->C D->Q Q->D E->R R->E F->S S->F G->T T->G H->U U->H I->V V->I J->W W->J\nK->X X->K L->Y Y->L M->Z Z->M\n\nOnly those letters which occur in the English alphabet are affected;\nnumbers, symbols, punctuation, whitespace, and all other characters are\nleft unchanged.\n\nFor example, the text \"Sphinx of black quartz, judge my vow.\" becomes\n\"Fcuvak bs oynpx dhnegm, whqtr zl ibj.\" when ROT13 is applied.",
        "output": "Guvf zrnaqn qvpxr!"
    },
    {
        "instruction": "ROT13 the following sentence: \"The sun shines on the meadow\"",
        "input": "ROT13 (or rot13, Rot13 or ROT-13) is a simple letter substitution cipher\nthat replaces a letter with the 13th letter after it in the Latin\nalphabet.\n\nApplying ROT13 to a text fragment requires examining its alphabetic\ncharacters and replacing each one by the letter 13 places further along in\nthe alphabet, wrapping back to the beginning if necessary. A becomes N, B\nbecomes O, and so on up to M, which becomes Z, then the sequence continues\nat the beginning of the alphabet: N becomes A, O becomes B, and so on to\nZ, which becomes M.\n\nTherefore, the letters are mapped as follows: A->N N->A B->O O->B C->P\nP->C D->Q Q->D E->R R->E F->S S->F G->T T->G H->U U->H I->V V->I J->W W->J\nK->X X->K L->Y Y->L M->Z Z->M\n\nOnly those letters which occur in the English alphabet are affected;\nnumbers, symbols, punctuation, whitespace, and all other characters are\nleft unchanged.\n\nFor example, the text \"Sphinx of black quartz, judge my vow.\" becomes\n\"Fcuvak bs oynpx dhnegm, whqtr zl ibj.\" when ROT13 is applied.",
        "output": "Gur svthr vf n pbzzr, gur zrffntr gb ybfg vf abj."
    },
    {
        "instruction": "Tell me if the following text is already ROT13 encoded or not: \"Gur dhvpx oebja sbk whzcf bire gur ynml qbt\"",
        "input": "The input is the same as the previous instruction, as there is no need for a specific example for this type of instruction.",
        "output": "Yes, the text is already ROT13 encoded."
    },
    {
        "instruction": "Provide an example of text that is ROT13 encoded using the alphabet mapping provided earlier",
        "input": "The rot13 skill enables encoding text with ROT13, which replaces each letter in the alphabet with the letter 13 places further along in the alphabet, wrapping back to the beginning if necessary. The letters are mapped as follows: A->N N->A B->O O->B C->P P->C D->Q Q->D E->R R->E F->S S->F G->T T->G H->U U->H I->V V->I J->W W->J K->X X->K L->Y Y->L M->Z Z->M",
        "output": "The rot13 skill enables encoding text with ROT13, which replaces each letter in the alphabet with the letter 13 places further along in the alphabet, wrapping back to the beginning if necessary. The letters are mapped as follows: A->N N->A B->O"
    }
]
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)