### PR TITLE
Add an E-Prime rewriting skill

### DIFF
--- a/compositional_skills/writing/grounded/editing/e-prime/qna.yaml
+++ b/compositional_skills/writing/grounded/editing/e-prime/qna.yaml
@@ -1,0 +1,52 @@
+created_by: t184256
+seed_examples:
+  - answer: This continues to pose a problem for us.
+    context: This is still a problem.
+    question: Rewrite the given sentence into E-Prime.
+  - answer: Though outliers exist.
+    context: Though there are outliers.
+    question: |
+      Rewrite without using "to be", so that the sentence conforms to E-Prime.
+  - answer: The full responsibility lies on me.
+    context: I'm the one fully responsible for this.
+    question: Rephrase this sentence to avoid any forms "to be".
+  - answer: 'Until then, the situation remains unchanged.'
+    context: 'Until then, it is the way it is.'
+    question: Eliminate all forms of the verb "to be" from this sentence.
+  - answer: It has a pleasant heft to it.
+    context: It's pleasantly heavy.
+    question: |
+      Rewrite the given sentence in a way that does not use the verb "to be".
+  - answer: Roam the streets of a majestic city located just two miles away.
+    context: Roam the streets of a majestic city that is just two miles away.
+    question: Rewrite the given text into E-Prime.
+  - answer: |
+      Look at me, I have become an adult.
+    context: |
+      Look at me, I'm an adult now.
+    question: |
+      Rewrite without using "to be", so that the sentence conforms to E-Prime.
+  - answer: >
+      She makes me so angry. Her failure seems imminent, yet she does not
+      relent.
+    context: |
+      I'm so angry at her. She's about to fail, yet she's unrelenting.
+    question: Rephrase this text to avoid any forms "to be".
+  - answer: >
+      This food tastes disgusting. I can't help but wonder why they consider it
+      edible.
+    context: This food is disgusting. How is it even considered edible?
+    question: |
+      Rewrite the given text in a way that does not use any forms of "to be".
+  - answer: >
+      The parser places further restrictions on the right hand side values
+      validity. It accepts either numeric literals or constants resolvable into
+      numbers.
+    context: >
+      There are further parsing restrictions on which right hand side values are
+      considered valid. They could be either numeric literals or constants that
+      can be resolved into numbers.
+    question: Eliminate all forms of the verb "to be" from this text.
+task_description: >
+  Provides examples of rewriting text into E-Prime, a subset of English that
+  prohibits all forms of the verb "to be".


### PR DESCRIPTION
**Add more examples of rewriting text to E-Prime, a subset of English avoiding the verb "to be".**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

The model seems to know what E-Prime is (usually describes it as avoiding "to be", although it sometimes also wants to eliminate modal verbs as well). But when tasked with rewriting text into E-Prime, it oftentimes struggles with eliminating any or all usages of "to be". Maybe it could use some more examples.


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
>>> Rewrite into E-Prime: "Dolphins are mammals"
```

```
>>> Rewrite into E-Prime: "He's back and he's well-rested"
```

```
>>> Rewrite into E-Prime: "I am done with this task, it was exhausting"
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
In E-Prime, we avoid using the verb "to be" in its various forms (am, is, are,
was, were, be, been, being) to enhance cognitive complexity and clarity. To
rewrite the statement "Dolphins are mammals" in E-Prime, we can use the word
"dolphin" as the subject and include the necessary information in the
predicate. Here's the rewritten statement:

Dolphins are mammals. (Original)

Dolphins are a type of mammal. (E-Prime)

This rephrased version maintains the original meaning while adhering to the
principles of E-Prime.
```

```
In E-Prime, we avoid using the verb "to be" as much as possible, so let's
rephrase the statement to avoid using it. Here's a possible rephrasing:

"He has returned and appears to be in good condition."

Explanation:
The original statement uses the verb "is," which is a form of the verb "to be."
In E-Prime, we aim to avoid using this verb to make our language more active
and direct. In this case, we can rephrase the statement to say that "he has
returned" and "appears to be in good condition," which avoids using the verb
"to be" entirely.
```

```
In E-Prime, we avoid using the verb "to be" and its derivatives. Here's a
rephrased version:

"This task is now complete. It proved to be challenging.

This revised statement maintains the original meaning while adhering to the
principles of E-Prime.
```



**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

TBD, not tested yet

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
