### PR TITLE
[WIP] Translating Pacenotes from one scheme to another

### DIFF
--- a/compositional_skills/extraction/information/named_entities/sports/motor/qna.yaml
+++ b/compositional_skills/extraction/information/named_entities/sports/motor/qna.yaml
@@ -1,0 +1,44 @@
+---
+created_by: durandom
+seed_examples:
+  - answer: |
+      The Reverse Numeric format would "6 left", "4 right", "1 right", "5 left", "3 left", "2 right"
+    context: |
+      | Numeric | Reverse Numeric | Desriptive |
+      |---------|-----------------|------------|
+      | 1       | 6               | Hairpin    |
+      | 2       | 5               | Bad        |
+      | 3       | 4               | 90         |
+      | 4       | 3               | Medium     |
+      | 5       | 2               | Fast       |
+      | 6       | 1               | Easy       |
+    question: |
+      Given the the notes in Numeric format: "1 left", "3 right", "6 right",  "2 left", "4 left", "5 right". Reformat the notes into Reverse Numeric format.
+  - answer: |
+      The reformatted notes in descriptive format are: "Hairpin left", "90 right", "Easy right", "Bad left", "Medium left", "Fast right".
+    context: |
+      | Numeric | Reverse Numeric | Desriptive |
+      |---------|-----------------|------------|
+      | 1       | 6               | Hairpin    |
+      | 2       | 5               | Bad        |
+      | 3       | 4               | 90         |
+      | 4       | 3               | Medium     |
+      | 5       | 2               | Fast       |
+      | 6       | 1               | Easy       |
+    question: |
+      Given the the notes in Numeric format: "1 left", "3 right", "6 right",  "2 left", "4 left", "5 right". Reformat the notes into descriptive format.
+  - answer: |
+      The reformatted notes in numeric format are: "6 left", "4 right", "1 right", "5 left", "3 left", "2 right".
+    context: |
+      | Numeric | Reverse Numeric | Desriptive |
+      |---------|-----------------|------------|
+      | 1       | 6               | Hairpin    |
+      | 2       | 5               | Bad        |
+      | 3       | 4               | 90         |
+      | 4       | 3               | Medium     |
+      | 5       | 2               | Fast       |
+      | 6       | 1               | Easy       |
+    question: |
+      Given the the notes in Reverse Numeric format: "1 left", "3 right", "6 right",  "2 left", "4 left", "5 right". Reformat the notes into Numeric format.
+task_description: |
+  Translating Pacenotes from one scheme to another - or translating entries from mapping tables with additional noise.


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

- translating entries from mapping tables with additional noise.
- or translating rally pacenotes from one format into another format


**Input given at the prompt**


```
| Numeric | Reverse Numeric | Desriptive |
|---------|-----------------|------------|
| 1       | 6               | Hairpin    |
| 2       | 5               | Bad        |
| 3       | 4               | 90         |
| 4       | 3               | Medium     |
| 5       | 2               | Fast       |
| 6       | 1               | Easy       |

In a rally roadbook, given the the pacenotes in Numeric format: "1 left", "3 right", "6 right",  "2 left", "4 left", "5 right". Refor
mat the notes into descriptive format.
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
│ The reformatted pacenotes in descriptive format are: "Hairpin left", "90 right", "Fast right", "Easy left", "Medium left", "Bad right". │
│ In this format, "90" represents a 90-degree right turn, making it easier for the driver to understand the road conditions better.       │
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] Contribution was tested with `lab generate`
- [ ] No errors or warnings were produced by `lab generate`
- [ ] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
