### PR TITLE
Add examples for one-line ascii emojis

### DIFF
--- a/compositional_skills/writing/freeform/chat/emojis/qna.yaml
+++ b/compositional_skills/writing/freeform/chat/emojis/qna.yaml
@@ -1,0 +1,19 @@
+created_by: ianballou
+seed_examples:
+  - answer: (☞ﾟヮﾟ)☞
+    question: Print an ascii emoji of a happy face with two pointing fingers.
+  - answer: (☞ ͡° ͜ʖ ͡°)☞
+    question: Print an ascii emoji of a neutral face with two pointing fingers.
+  - answer: (☞ﾟヮﾟ)☞ ☜(ﾟヮﾟ☜)
+    question: Print an ascii emoji of two happy faces pointing at each other.
+  - answer: ヽ(*^ｰ^)人(^ｰ^*)ノ
+    question: Print an ascii emoji of two happy faces high-fiving.
+  - answer: (⌐■_■)
+    question: Print an ascii emoji of a face with sunglasses.
+  - answer: (•_•) ( •_•)>⌐■-■ (⌐■_■)
+    question: Print an ascii emoji of a face putting on sunglasses.
+  - answer: ¯\_(ツ)_/¯
+    question: Print an ascii emoji of a shrugging face.
+  - answer: (ÒДÓױ)
+    question: Print an ascii emoji of an angry face.
+task_description: ''


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Adds single-line acsii emojis. Currently, when asked to print an ascii emoji, the model attempts to make a large ascii drawing (that doesn't make sense) rather than something simple. 


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   Print me an ascii emoji with pointing fingers
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  ╭─────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ────────────────────────────────────────────────────────────╮
│ Here's an ASCII representation of an emoji with pointing fingers:                                                                          │
│                                                                                                                                            │
│ ```                                                                                                                                        │
│  ______                                                                                                                                    │
│ <(______)______>                                                                                                                           │
│ <(______)______>                                                                                                                           │
│ <(______)______>                                                                                                                           │
│  <(_____)____>                                                                                                                             │
│   '._   _.'                                                                                                                                │
│  /   `\\ /                                                                                                                                 │
│  \\   |  /                                                                                                                                 │
│  /   /  \\                                                                                                                                 │
│ /___/_____\                                                                                                                                │
│    /   /\                                                                                                                                  │
│  /   /  \                                                                                                                                  │
│ /_____/__\                                                                                                                                 │
│ ```                                                                                                                                        │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 14.462 seconds ─╯
```


**Response that is now received instead**

I haven't been able to train the model yet to do a real test, but based on what's in the test and train jsonl files, it should start showing one-line ascii emojis rather than the incomprehensible ascii art that it's currently showing.

Random snippet from the generated training data:

```
{"system": "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.", "user": "8. Print an ascii emoji of a<dummy00001>ive face.", "assistant": "\ud83e\udd17"}
{"system": "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.", "user": "9. Print an ascii emoji of a surprised face.", "assistant": "\ud83d\ude32"}
{"system": "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.", "user": "10. Print an ascii emoji of a angry face.", "assistant": "\ud83d\ude20"}
{"system": "You are an AI language model developed by IBM Research. You are a cautious assistant. You carefully follow instructions. You are helpful and harmless and you follow ethical guidelines and promote positive behavior.", "user": "11. Print an ascii emoji of a dancing face.", "assistant": "\ud83d\udc83"}
```

The representations of the emojis may not all be correct, however my point here is to stop the giant text blocks that it currently produces.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
