### PR TITLE
Add tox yamllint linter

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,12 @@
+---
+
+extends: relaxed
+
+ignore:
+  - .tox/
+  - .github/
+
+rules:
+  line-length:
+    level: error
+    max: 120

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,1 @@
+yamllint>=1.35.1 #GPLv3

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[tox]
+envlist = lint
+minversion = 3.18.0
+skipsdist = True
+
+[testenv]
+deps = -r{toxinidir}/test-requirements.txt
+
+[testenv:lint]
+commands = yamllint {toxinidir}/compositional_skills/ {toxinidir}/knowledge/


### PR DESCRIPTION
This PR adds a yamllint tox environment using the github workflow's
yamllint settings.

Signed-off-by: Daniel Mellado <dmellado@redhat.com>