### PR TITLE
Update an unusual cricket situation

### DIFF
--- a/compositional_skills/writing/freeform/sports/cricket/qna.yaml
+++ b/compositional_skills/writing/freeform/sports/cricket/qna.yaml
@@ -1,6 +1,6 @@
 reated_by: sushilkulkarni
 seed_examples:
-- answer: 'To put it in simple terms, Mankading refers to the act of dismissing a non striker batter before a ball is bowled by running him out. According to Cricket law 38.3.1 At any time from the moment the ball comes into play until the instant when the bowler would normally have been expected to release the ball, the non-striker is liable to be Run out if he/she is out of his/her ground. In these circumstances the non-striker will be out Run out if he/she is out of his/her ground when his/her wicket is broken by the bowler throwing the ball at the stumps or by the bowler’s hand holding the ball, whether or not the ball is subsequently delivered.
+- answer: 'To put it in simple terms, Mankading refers to the method of dismissing a non-striker batsman before a ball is bowled by running him/her out. According to Cricket law 38.3.1 At any time from the moment the ball comes into play until the instant when the bowler would normally have been expected to release the ball, the non-striker is liable to be Run out if he/she is out of his/her ground. In these circumstances the non-striker will be out Run out if he/she is out of his/her ground when his/her wicket is broken by the bowler throwing the ball at the stumps or by the bowler’s hand holding the ball, whether or not the ball is subsequently delivered.
     '
   question: Tell me what mankading is named after
 - answer: 'It is named after the Indian Cricket Player Vinoo Mankad

--- a/compositional_skills/writing/freeform/sports/cricket/qna.yaml
+++ b/compositional_skills/writing/freeform/sports/cricket/qna.yaml
@@ -2,7 +2,7 @@ created_by: sushilkulkarni
 seed_examples:
   - answer: >-
       To put it in simple terms, Mankading refers to the act of dismissing a non
-      striker batter before a ball is bowled by running him/herout. According to
+      striker batter before a ball is bowled by running him/her out. According to
       Cricket law 38.3.1 At any time from the moment the ball comes into play
       until the instant when the bowler would normally have been expected to
       release the ball, the non-striker is liable to be Run out if he/she is out
@@ -11,7 +11,7 @@ seed_examples:
       the bowler throwing the ball at the stumps or by the bowler’s hand holding
       the ball, whether or not the ball is subsequently delivered.
     question: Tell me what is Mankading
-  - answer: 'It is named after the Indian Cricket Player Vinoo Mankad '
+  - answer: It is named after the Indian Cricket Player Vinoo Mankad
     question: Tell me who is Mankading named after
   - answer: The non-striking batsman gets dismissed in a Mankading scenario
     question: Tell me who gets out when Mankaded

--- a/compositional_skills/writing/freeform/sports/cricket/qna.yaml
+++ b/compositional_skills/writing/freeform/sports/cricket/qna.yaml
@@ -13,4 +13,6 @@ seed_examples:
     question: Tell me what is Mankading
   - answer: 'It is named after the Indian Cricket Player Vinoo Mankad '
     question: Tell me who is Mankading named after
-task_description: ''
+  - answer: The non-striking batsman gets dismissed in a Mankading scenario
+    question: Tell me who gets out when Mankaded
+task_description: Update an unusual cricket situation

--- a/compositional_skills/writing/freeform/sports/cricket/qna.yaml
+++ b/compositional_skills/writing/freeform/sports/cricket/qna.yaml
@@ -1,0 +1,9 @@
+reated_by: sushilkulkarni
+seed_examples:
+- answer: 'To put it in simple terms, Mankading refers to the act of dismissing a non striker batter before a ball is bowled by running him out. According to Cricket law 38.3.1 At any time from the moment the ball comes into play until the instant when the bowler would normally have been expected to release the ball, the non-striker is liable to be Run out if he/she is out of his/her ground. In these circumstances the non-striker will be out Run out if he/she is out of his/her ground when his/her wicket is broken by the bowler throwing the ball at the stumps or by the bowler’s hand holding the ball, whether or not the ball is subsequently delivered.
+    '
+  question: Tell me what mankading is named after
+- answer: 'It is named after the Indian Cricket Player Vinoo Mankad
+    '
+  question: Tell me who is mankading named after
+task_description: ''

--- a/compositional_skills/writing/freeform/sports/cricket/qna.yaml
+++ b/compositional_skills/writing/freeform/sports/cricket/qna.yaml
@@ -1,9 +1,16 @@
-reated_by: sushilkulkarni
+created_by: sushilkulkarni
 seed_examples:
-- answer: 'To put it in simple terms, Mankading refers to the method of dismissing a non-striker batsman before a ball is bowled by running him/her out. According to Cricket law 38.3.1 At any time from the moment the ball comes into play until the instant when the bowler would normally have been expected to release the ball, the non-striker is liable to be Run out if he/she is out of his/her ground. In these circumstances the non-striker will be out Run out if he/she is out of his/her ground when his/her wicket is broken by the bowler throwing the ball at the stumps or by the bowler’s hand holding the ball, whether or not the ball is subsequently delivered.
-    '
-  question: Tell me what mankading is named after
-- answer: 'It is named after the Indian Cricket Player Vinoo Mankad
-    '
-  question: Tell me who is mankading named after
+  - answer: >-
+      To put it in simple terms, Mankading refers to the act of dismissing a non
+      striker batter before a ball is bowled by running him/herout. According to
+      Cricket law 38.3.1 At any time from the moment the ball comes into play
+      until the instant when the bowler would normally have been expected to
+      release the ball, the non-striker is liable to be Run out if he/she is out
+      of his/her ground. In these circumstances the non-striker will be out Run
+      out if he/she is out of his/her ground when his/her wicket is broken by
+      the bowler throwing the ball at the stumps or by the bowler’s hand holding
+      the ball, whether or not the ball is subsequently delivered.
+    question: Tell me what is Mankading
+  - answer: 'It is named after the Indian Cricket Player Vinoo Mankad '
+    question: Tell me who is Mankading named after
 task_description: ''


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

Making the AI response to an unusual situation in the game of Cricket clearer. The current answer has errors.

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Better definition of the scenario with the official rule

**Input given at the prompt**

<!-- What you entered, replace "..." -->

What is Mankad out?


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

The Mankad dismissal, also known as "run-out" or "run-out stumping," refers to a method of dismissing a batsman in cricket when the bowler dislodges the batsman's bail(s) before the batsman has had the opportunity to score runs. This situation typically arises when the  bowler's delivery stride takes them in front of the crease and they dislodge the batsman's bail(s) while the batsman is still in the  process of playing the ball. The bowler must deliver the ball within the law (not obstructing the batsman's path) and the batsman must not have completed their shot when the bail(s) are dislodged.             
                                                                                                                                                                                                               
This dismissal method was first made popular by Indian cricketer Vinoo Mankad in 1947 when he ran out Australian batsman Bill Brown in this manner. The incident sparked controversy and led to the creation of Law 41.10 in the Laws of Cricket, which officially permits the Mankad dismissal. However, it is considered unsportsmanlike to run out the non-striker in this manner during the course of the delivery,  so many captains choose not to use this method unless the non-striker is aware of the risk and has been warned previously.                                                                                                                                          

In summary, the Mankad dismissal is a unique way to dismiss a batsman in cricket, where the bowler dislodges the batsman's bail(s) before they have completed their shot, adhering to the Law 41.10 of the Laws of Cricket.   


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->
...

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ x] Contribution was tested with `lab generate`
- [ x] No errors or warnings were produced by `lab generate`
- [ x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
