### PR TITLE
add some pangrams

### DIFF
--- a/compositional_skills/writing/freeform/prose/pangrams/qna.yaml
+++ b/compositional_skills/writing/freeform/prose/pangrams/qna.yaml
@@ -1,0 +1,17 @@
+created_by: richm
+seed_examples:
+- answer: A brown jug and a quick minx have fun and play zestfully.
+  question: Write a pangram with the word jug.
+- answer: Why does the quiz make prim bacon fig jelly vexed?
+  question: Write a pangram with the word bacon.
+- answer: Canny pox finks make the best quotidian jungle wizard views.
+  question: Write a pangram with the word wizard.
+- answer: Jolly quartz boxes make for happy dancing wig vials.
+  question: Write a pangram with the word quartz.
+- answer: Quiz me nightly for a wicked perspex job view.
+  question: Write a pangram with the word wicked.
+- answer: Wax eloquently about perfectly good massive hi jinks at the zoo.
+  question: Write a pangram with the word zoo.
+- answer: We must have quietly displaced the box of jokers in the game zone.
+  question: Write a pangram with the word jokers.
+task_description: Training about pangrams.


### PR DESCRIPTION
Add some pangrams to try to improve the output.  Just in case it isn't obvious - a pangram is a sentence that contains every letter in the alphabet at least once (a perfect pangram contains all of the letters exactly once - "Cwm finks vex'd quartz glyph job.").  The following assumes the English alphabet with American spelling.  As you can see from the below, the model was not so good, generating phrases with most of the words having the same first letter, and not usually generating correct pangrams.  After training, the output was much improved.

This is the output of collab, which shows the user (i.e. me) prompt, the
old output before training with the new data, the output after training,
and the expected answer given in the qna.yaml.

=================================================

## test 0

### user

Write a pangram with the word jug.

### assistant_old

A jug of juice gathers dust on the shelf,
While juggling balls juggles jugs,
And juggler jugs jugs,
Juggling with jugs,
[dozens of the same lines omitted for brevity],
Juggling with jugs,

### assistant_new

Juggling wizards play quizzically while juggling the jugs.

### assistant_expected

A brown jug and a quick minx have fun and play zestfully.

## test 1

### user

Write a pangram with the word bacon.

### assistant_old

A quick brown fox jumps over a lazy dog.
This phrase contains all the letters of the alphabet, including "bacon".

Or, for a more culinary-themed pangram:

Bacon, eggs, fried, garnished with ham, in oven, juice, ketchup, lemon, mustard, nachos, onion, pizza, quiche, relish, salad, tacos, and vinegar.

This sentence contains all the letters of the alphabet, including "bacon", and showcases various dishes that could potentially include bacon.

### assistant_new

Bacon, fig, jelly, kind, lime, milk, ostrich, "it's" vexed.

### assistant_expected

Why does the quiz make prim bacon fig jelly vexed?

## test 2

### user

Write a pangram with the word wizard.

### assistant_old

A quick wizard, with a wooden wand,
Vanished to a distant, mystical land.
Zigzagging through ancient, enchanted trees,
Invisible, as if by magic, he flees.
"Duck!" he whispers, as lightning strikes near,
Nearby, a river, clear and bright,
He dives in, and swims out of sight.
No one knows where he'll appear next,
But one thing is certain, he'll never be detained,
For he's a wizard, and magic is his name!

### assistant_new

Cunning foxes play near the wizard's house.

### assistant_expected

Canny pox finks make the best quotidian jungle wizard views.

## test 3

### user

Write a pangram with the word quartz.

### assistant_old

A quartz clock keeps correct time, but it's rarely seen.

### assistant_new

Quartz quasically exits the jungle and quickly rushes to the river.

### assistant_expected

Jolly quartz boxes make for happy dancing wig vials.

## test 4

### user

Write a pangram with the word wicked.

### assistant_old

A quick brown fox jumps over a lazy dog.

This sentence is a pangram, which means it uses every letter of the alphabet at least once. The word "wicked" has been added to the sentence, which is already a pangram, to create a new sentence that still includes all the letters. The sentence now reads: "A quick wicked fox jumps over a lazy dog." This new sentence maintains its pangrammatic properties while incorporating the word "wicked."

### assistant_new

Wicked vixen juggles honey, flour, and jaywalks.

### assistant_expected

Quiz me nightly for a wicked perspex job view.

## test 5

### user

Write a pangram with the word zoo.

### assistant_old

A quick zebra, out of the zoo, now runs free.

### assistant_new

Zoo, grab the birdseed, and feed the birds.

### assistant_expected

Wax eloquently about perfectly good massive hi jinks at the zoo.

## test 6

### user

Write a pangram with the word jokers.

### assistant_old

A pangram is a sentence that uses every letter of the alphabet at least once. Here's a pangram that includes the word "jokers":

"Jokers' jokes jolt jaded jockeys jogging jovially jutting jocularly jutting jokingly."

This sentence contains all the letters of the alphabet, including the letter "e" which is not explicitly present in the word "jokers" but is included in the other words in the sentence.

### assistant_new

Jokers play hide-and-seek zestfully while the spectators watch.

### assistant_expected

We must have quietly displaced the box of jokers in the game zone.

------------------------------------------

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
