### PR TITLE
skill: Add reasoning skill about siblings

### DIFF
--- a/compositional_skills/extraction/inference/qualitative/siblings/qna.yaml
+++ b/compositional_skills/extraction/inference/qualitative/siblings/qna.yaml
@@ -1,0 +1,28 @@
+created_by: russellb
+task_description: Reasoning about sibling relationships
+seed_examples:
+  - answer: |
+      David has three sisters, and each of them has one brother.
+      David is their one brother. So, David has no brothers.
+    question: |
+      David has three sisters. Each of them has one brother. How many brothers does David have?
+  - answer: |
+      David has three sisters, and each of them has two brothers.
+      David is one of their brothers. So, David has one brother.
+    question: |
+      David has three sisters. Each of them has two brothers. How many brothers does David have?
+  - answer: |
+      Sally has three brothers, and each of them has one sister.
+      Sally is their one sister. So, Sally has no sisters.
+    question: |
+      Sally has three brothers. Each of them has one sister. How many sisters does Sally have?
+  - answer: |
+      Sally has three brothers, and each of them has two sisters.
+      Sally is their one sister. So, Sally has one sister.
+    question: |
+      Sally has three brothers. Each of them has two sisters. How many sisters does Sally have?
+  - answer: |
+      Sally has one brother and one sister. There are two sisters and one brother.
+      Sally's brother has two sisters.
+    question: |
+      Sally has one brother and one sister. How many sisters does Sally's brother have?


### PR DESCRIPTION
This skill was inspired by one of the tests included in mt-bench. It
included some questions that the model answered incorrectly. When
given the same question manually, I got the following answer:

> Q: David has three sisters. Each of them has one brother. How many
>    brothers does David have?
> A: David has three sisters, and each of them has one brother, so it
>    must be the same brother in all cases. Therefore, David has 1 brother.

After a `lab generate`, `lab train`, and `lab convert`, I got a better
answer some of the time.

> A: David having three sisters, each of them having one brother,
>    implies that David is their one brother. Therefore, David has no
>    brothers.

Or a correct but awkwardly phrased answer:

> A: Based on the information provided, if each of David's three
>    sisters also has one brother, then that brother is David himself.
>    Therefore, David has no brothers since he is his own brother.

but sometimes still an incorrect answer:

> A: David has three sisters, each of whom states that she has one
>    brother. This implies that David is indeed her brother, so David
>    has one brother.

> A: David having three sisters, each of their statement confirms that
>    David is their brother. Therefore, David would have one brother, which
>    is himself, as stated in the question.

Signed-off-by: Russell Bryant <rbryant@redhat.com>