### PR TITLE
Add words filtering skill

### DIFF
--- a/compositional_skills/extraction/inference/quantitative/words_analysis/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/words_analysis/qna.yaml
@@ -1,0 +1,18 @@
+created_by: morucci
+seed_examples:
+- answer: 'The filtered list of words is: mouse, dentist
+    '
+  context: dog, cat, mouse, dentist
+  question: 'Filter the following list of words by keeping only the words composed of the letter "e"
+    '
+- answer: 'The filtered list of words is: dog, mouse
+    '
+  context: dog, cat, mouse, dentist
+  question: 'Filter the following list of words by keeping only the words composed of the letter "o"
+    '
+- answer: 'The filtered list of words is: dog, dentist
+    '
+  context: dog, cat, mouse, dentist
+  question: 'Filter the following list of words by keeping only the words composed of the letter "d"
+    '
+task_description: 'Ability to filter a list of words based on the predicate if it contains the given letter.'


### PR DESCRIPTION
Based on a list of words, filter the list by words containing a specific letter.

This attempts to fix the following issue:

>>> Filter the following list of words by keeping only the words that include the letter 'i': dog, cat, mouse, dentist
The filtered list of words is: cat, dentist

If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- fix capability to filter words by on the 'include letter x' predicate

**Input given at the prompt**

```
Filter the following list of words by keeping only the words that include the letter 'i': dog, cat, mouse, dentist
```


**Response that was received**

```
The filtered list of words is: cat, dentist
```


**Response that is now received instead**

I unfortunately don't see a differences in the replies after running lab generate and restarting the lab chat command. So guidance is welcome

```
  ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [ ] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
