### PR TITLE
compositional_skills: Add a skill to order adjectives

### DIFF
--- a/compositional_skills/writing/grounded/editing/adjectives_ordering/qna.yaml
+++ b/compositional_skills/writing/grounded/editing/adjectives_ordering/qna.yaml
@@ -1,0 +1,22 @@
+task_description: |
+    This skill provides the ability to read properly order adjectives.
+created_by: martinezjavier
+seed_examples:
+  - context: |
+      big, blue, amazing
+    question: |
+      Correctly order the following adjectives:
+    answer: |
+      The correct order for the adjectives is: amazing, big, blue.
+  - context: |
+      lovely, plastic, square
+    question: |
+      Correctly order the following adjectives:
+    answer: |
+      The correct order for the adjectives is: lovely, square, plastic.
+  - context: |
+      cooking, old, heavy.
+    question: |
+      Correctly order the following adjectives:
+    answer: |
+      The correct order for the adjectives is: old, heavy, cooking.


### PR DESCRIPTION
I wanted the model to properly order adjectives. But three questions I asked and was not able to do it:

**Describe the contribution to the taxonomy**

Add a compositional_skills/writing/grounded/editing/adjectives_ordering skill with examples on how to correctly order adjectives according to the English grammar rules:

https://dictionary.cambridge.org/grammar/british-grammar/adjectives-order

**Input given at the prompt**

   >>> Correctly order the following adjectives: big, blue, amazing
    ╭──────────────────────────────────────────────── merlinite-7b-Q4_K_M ──
    │ The correct order for the adjectives is: big, blue, amazing.
    ╰─────────────────────────────────────────────────────────────────
    >>> Correctly order the following adjectives: lovely, plastic, square
    ╭──────────────────────────────────────────────── merlinite-7b-Q4_K_M ──
    │ The correct order for the adjectives is: lovely, plastic, square.
    ╰─────────────────────────────────────────────────────────────────
    >>> Correctly order the following adjectives: cooking, old, heavy
    ╭──────────────────────────────────────────────── merlinite-7b-Q4_K_M ──
    │ The correct order for the adjectives is: cooking, old, heavy.
    ╰─────────────────────────────────────────────────────────────────

**Response that is now received instead**

I was not able to test the taxonomy because `lab generate` keeps timing out in my laptop.

```
$ lab generate
INFO 2024-03-09 03:47:37,944 lab.py:315 Generating model 'merlinite-7b-Q4_K_M' using 10 cpus, taxonomy: 'taxonomy' and seed 'seed_tasks.json'
  0%|                                                                                          | 0/100 [00:00<?, ?it/s]Cannot find prompt.txt. Using default prompt.
Synthesizing new instructions. If you aren't satisfied with the generated instructions, interrupt training (Ctrl-C) and try adjusting your YAML files. Adding more examples may help.
Error connecting to the server: timed out
```

**Contribution checklist**

- [ ] Contribution was tested with `lab generate`
- [ ] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)