### PR TITLE
skills to compare versions in N(.N)* format

### DIFF
--- a/compositional_skills/extraction/inference/versions_compare/qna.yaml
+++ b/compositional_skills/extraction/inference/versions_compare/qna.yaml
@@ -1,0 +1,28 @@
+task_description: |
+  skills to compare versions in N(.N)* format
+created_by: liangxiao1
+seed_examples:
+  - question: package version 8.1.12 and 8.1.2, which is higher?
+    answer: |
+      8.1.12 is higher than 8.1.2. Here is the documentation that may be helpful.
+      https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers
+  - question: xxx-9.22.1 and xxx-9.4.7, which is higher?
+    answer: |
+      xxx-9.22.1 is higher than xxx-9.4.7. Here is the documentation that may be helpful.
+      https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers
+  - question: yyy-9.6 and yyy-9.3.7, which is higher?
+    answer: |
+      yyy-9.6 is higher than yyy-9.3.7. Here is the documentation that may be helpful.
+      https://packaging.python.org/en/latest/specifications/version-specifiers/#version-specifiers
+  - question: yyy-9.6 and xxx-5.3.7, which is higher?
+    answer: |
+      The package names are different, and it is meaningless to judge which one is higher.
+  - question: cloud-init-22.1-7.el9_1 and kernel-5.14.0-70.13.1.el9_0, which is higher?
+    answer: |
+      The package names are different, and it is meaningless to judge which one is higher.
+  - question: kernel-5.14.0-70.26.1.el9_0 and 5.14.0-162.6.1.el9_1, which is higher?
+    answer: |
+      5.14.0-162.6.1.el9_1 is higher than 5.14.0-70.26.1.el9_0.
+  - question: kernel-5.14.0-70.13.1.el9_0 and kernel-5.14.0-70.8.1.el9_0, which is higher?
+    answer: |
+      kernel-5.14.0-70.13.1.el9_0 is higher than kernel-5.14.0-70.8.1.el9_0.


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

- Compare versions in N(.N)* format, like kernel-5.14.0-70.13.1.el9_0 is higher than kernel-5.14.0-70.8.1.el9_0.
- Do not compare the two versions if the package names are not the same.


**Input given at the prompt**


```
>>> kernel-5.14.0-70.13.1.el9_0 and kernel-5.14.0-70.8.1.el9_0, which is higher?
```


**Response that was received**


```
>>> kernel-5.14.0-70.13.1.el9_0 and kernel-5.14.0-70.8.1.el9_0, which is higher?                                                                 [S][default]
╭─────────────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ───────────────────────────────────────────────────────────────────╮
│ Based on the naming convention, the kernel version with the higher kernelrelease number is higher. In this case, kernel-5.14.0-70.8.1.el9_0 has a higher  │
│ kernelrelease number than kernel-5.14.0-70.13.1.el9_0.                                                                                                    │
╰────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 13.152 seconds ─╯

```


**Response that is now received instead**


```
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
