### PR TITLE
Add skill to extract bit positions from hex numbers

### DIFF
--- a/compositional_skills/writing/grounded/summarization/bitmask/qna.yaml
+++ b/compositional_skills/writing/grounded/summarization/bitmask/qna.yaml
@@ -1,0 +1,22 @@
+task_description: |
+  This skill provides the ability to extract bit numbers from hex bitmasks
+created_by: valschneider
+seed_examples:
+  - context: |
+      0x42
+    question: |
+      Which bits are set in the following number
+    answer: |
+      0x42 has bit 2 and bit 6 set.
+  - context: |
+      0xFED
+    question: |
+      Which bits are set in the following number
+    answer: |
+      0xFED has bit 0, 2, 3, 5, 6, 7, 8, 9, 10 and 11 set.
+  - context: |
+      0x0
+    question: |
+      Which bits are set in the following number
+    answer: |
+      0x0 has no bits set.


### PR DESCRIPTION
The model currently fails at this task, this should improve the situation.

**Describe the contribution to the taxonomy**

Give the bits set in a hex number. E.g. 0x2 == 0b10 => bit #1 set

**Input given at the prompt**

Which bits are set in the following number: 0x42                                                  

Which bits are set in the following number: 0xFED 

**Response that was received**

│ The hexadecimal number 0x42 is equivalent to the binary number 01000100, which is 12 in decimal notation. In   
│ binary form, the second bit (counting from right to left, starting from 0) is set. So, 01000100 is called 0x42.    

(0x42 is 0b0100.0010 and 66 in base 10.)


│ The hexadecimal number 0xFED is equivalent to the binary number 1111 1100 1101 100, which is 638 in decimal        
│ notation. To determine which bits are set, we can convert the binary number to binary form with set bits           
│ highlighted:                                                                                                       
│                                                                                                                    
│ 1 1 1 1 1 1 1 0 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0  │
│ 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0  │
│ 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0  │
│ 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0  │
│ 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0  │
│ 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0  │
│ 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0  │
│ 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 1 1 0 

(Issued a CTRL-C as it wasn't stopping and kept printing the same binary pattern)

**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

Couldn't run `lab train`

**Contribution checklist**

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
