### PR TITLE
New Skill: Setup simple SBD via pcs in HA-Cluster

### DIFF
--- a/compositional_skills/writing/freeform/technical/ha-cluster/setup-sbd/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/ha-cluster/setup-sbd/qna.yaml
@@ -38,19 +38,19 @@ seed_examples:
     `ls -l /dev/disk/by-id/`
     NOTE: A specific disk ids must be used to maintain persistence
     3. Setup chosen devices for SBD
-    `pcs stonith sbd device setup device=/dev/disk/by-id/<first-disk-id> device=/dev/disk/by-id/<second-disk-id> 
+    `pcs stonith sbd device setup device=/dev/disk/by-id/<first-disk-id> device=/dev/disk/by-id/<second-disk-id>
     device=/dev/disk/by-id/<third-disk-id>`
     4. Enable SBD fencing and specify the devices
-    `pcs stonith sbd enable device=/dev/disk/by-id/<first-disk-id> device=/dev/disk/by-id/<second-disk-id> 
+    `pcs stonith sbd enable device=/dev/disk/by-id/<first-disk-id> device=/dev/disk/by-id/<second-disk-id>
     device=/dev/disk/by-id/<third-disk-id>`
     5. Start the cluster
     `pcs cluster start --all`
     6. Create SBD fence agent
-    `pcs stonith create <agent-name> fence_sbd 
+    `pcs stonith create <agent-name> fence_sbd
     devices=/dev/disk/by-id/<first-disk-id>,/dev/disk/by-id/<second-disk-id>,/dev/disk/by-id/<third-disk-id>`
   question: How to configure SBD fencing with multiple disks in a pacemaker cluster?
 - answer: |
-    This is a way to configure SBD fencing with one shared disk with id /dev/disk/by-id/disk172731 in a running 
+    This is a way to configure SBD fencing with one shared disk with id /dev/disk/by-id/disk172731 in a running
     2-node pacemaker cluster, that would have a fence_sbd agent named fencing-agent-1:
     1. Stop the cluster
     `pcs cluster stop --all`
@@ -62,15 +62,15 @@ seed_examples:
     `pcs cluster start --all`
     5. Create SBD fence agent named fencing-agent-1
     `pcs stonith create fencing-agent-1 fence_sbd devices=/dev/disk/by-id/disk172731`
-  question: How to configure SBD fencing with one disk with id /dev/disk/by-id/disk172731 
+  question: How to configure SBD fencing with one disk with id /dev/disk/by-id/disk172731
     and fence agent with name fencing-agent-1 in a running 2-node pacemaker cluster?
 - answer: |
-    This is a way to configure SBD fencing with two shared disks with ids /dev/disk/by-id/disk17111 
-    and /dev/disk/by-id/disk17122 with watchdog device /dev/watchdog2 in a running 
+    This is a way to configure SBD fencing with two shared disks with ids /dev/disk/by-id/disk17111
+    and /dev/disk/by-id/disk17122 with watchdog device /dev/watchdog2 in a running
     2-node pacemaker cluster, that would have a fence_sbd agent named fencing-agent-sbd:
     1. Stop the cluster
     `pcs cluster stop --all`
-    2. Setup devices /dev/disk/by-id/disk17111 
+    2. Setup devices /dev/disk/by-id/disk17111
     and /dev/disk/by-id/disk17122 for SBD
     `pcs stonith sbd device setup device=/dev/disk/by-id/disk17111 device=/dev/disk/by-id/disk17122`
     3. Enable SBD fencing and specify the devices /dev/disk/by-id/disk17111 and /dev/disk/by-id/disk17122
@@ -81,5 +81,6 @@ seed_examples:
     5. Create SBD fence agent named fencing-agent-sbd
     `pcs stonith create fencing-agent-1 fence_sbd devices=/dev/disk/by-id/disk17111,/dev/disk/by-id/disk17122`
   question: How to configure SBD fencing with two disks with ids /dev/disk/by-id/disk17111 and /dev/disk/by-id/disk17122
-    and fence agent with name fencing-agent-sbd and watchdog device /dev/watchdog2 in a running 2-node pacemaker cluster?
+    and fence agent with name fencing-agent-sbd and watchdog device /dev/watchdog2
+    in a running 2-node pacemaker cluster?
 task_description: 'Setup of SBD fencing method in a 2-node pacemaker cluster via pcs cli'

--- a/compositional_skills/writing/freeform/technical/ha-cluster/setup-sbd/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/ha-cluster/setup-sbd/qna.yaml
@@ -1,0 +1,85 @@
+created_by: mmazoure
+seed_examples:
+- answer: |
+    This is a way to configure simple watchdog-only SBD fencing in a 2-node pacemaker cluster via pcs:
+    1. Stop the cluster if it's running
+    `pcs cluster stop --all`
+    2. Enable sbd fencing and set watchdog device
+    `pcs stonith sbd enable watchdog=/dev/watchdog`
+    NOTE: When watchdog device is not specified, the default /dev/watchdog is used
+    3. Start the cluster
+    `pcs cluster start --all`
+    4. Set stonith-watchdog-timeout
+    `pcs property set stonith-watchdog-timeout=10`
+    NOTE: The stonith-watchdog-timeout should be double of SBD_WATCHDOG_TIMEOUT (shown in `pcs stonith sbd config`).
+    This property is set only with SBD without shared disks.
+  question: How to configure simple SBD fencing without disks in a pacemaker cluster?
+- answer: |
+    This is a way to configure SBD fencing with one shared disk in a 2-node pacemaker cluster via pcs:
+    1. Stop the cluster if it's running
+    `pcs cluster stop --all`
+    2. Find shared devices on your system
+    `ls -l /dev/disk/by-id/`
+    NOTE: A specific disk id must be used to maintain persistence
+    3. Setup chosen device for SBD
+    `pcs stonith sbd device setup device=/dev/disk/by-id/<disk-id>`
+    4. Enable SBD fencing and specify the device
+    `pcs stonith sbd enable device=/dev/disk/by-id/<disk-id>`
+    5. Start the cluster
+    `pcs cluster start --all`
+    6. Create SBD fence agent
+    `pcs stonith create <agent-name> fence_sbd devices=/dev/disk/by-id/<disk-id>`
+  question: How to configure SBD fencing with one disk in a pacemaker cluster?
+- answer: |
+    This is a way to configure SBD fencing with multiple shared disks in a 2-node pacemaker cluster via pcs:
+    1. Stop the cluster if it's running
+    `pcs cluster stop --all`
+    2. Find shared devices on your system
+    `ls -l /dev/disk/by-id/`
+    NOTE: A specific disk ids must be used to maintain persistence
+    3. Setup chosen devices for SBD
+    `pcs stonith sbd device setup device=/dev/disk/by-id/<first-disk-id> device=/dev/disk/by-id/<second-disk-id> 
+    device=/dev/disk/by-id/<third-disk-id>`
+    4. Enable SBD fencing and specify the devices
+    `pcs stonith sbd enable device=/dev/disk/by-id/<first-disk-id> device=/dev/disk/by-id/<second-disk-id> 
+    device=/dev/disk/by-id/<third-disk-id>`
+    5. Start the cluster
+    `pcs cluster start --all`
+    6. Create SBD fence agent
+    `pcs stonith create <agent-name> fence_sbd 
+    devices=/dev/disk/by-id/<first-disk-id>,/dev/disk/by-id/<second-disk-id>,/dev/disk/by-id/<third-disk-id>`
+  question: How to configure SBD fencing with multiple disks in a pacemaker cluster?
+- answer: |
+    This is a way to configure SBD fencing with one shared disk with id /dev/disk/by-id/disk172731 in a running 
+    2-node pacemaker cluster, that would have a fence_sbd agent named fencing-agent-1:
+    1. Stop the cluster
+    `pcs cluster stop --all`
+    2. Setup device /dev/disk/by-id/disk172731 for SBD
+    `pcs stonith sbd device setup device=/dev/disk/by-id/disk172731`
+    3. Enable SBD fencing and specify the device /dev/disk/by-id/disk172731
+    `pcs stonith sbd enable device=/dev/disk/by-id/disk172731`
+    4. Start the cluster
+    `pcs cluster start --all`
+    5. Create SBD fence agent named fencing-agent-1
+    `pcs stonith create fencing-agent-1 fence_sbd devices=/dev/disk/by-id/disk172731`
+  question: How to configure SBD fencing with one disk with id /dev/disk/by-id/disk172731 
+    and fence agent with name fencing-agent-1 in a running 2-node pacemaker cluster?
+- answer: |
+    This is a way to configure SBD fencing with two shared disks with ids /dev/disk/by-id/disk17111 
+    and /dev/disk/by-id/disk17122 with watchdog device /dev/watchdog2 in a running 
+    2-node pacemaker cluster, that would have a fence_sbd agent named fencing-agent-sbd:
+    1. Stop the cluster
+    `pcs cluster stop --all`
+    2. Setup devices /dev/disk/by-id/disk17111 
+    and /dev/disk/by-id/disk17122 for SBD
+    `pcs stonith sbd device setup device=/dev/disk/by-id/disk17111 device=/dev/disk/by-id/disk17122`
+    3. Enable SBD fencing and specify the devices /dev/disk/by-id/disk17111 and /dev/disk/by-id/disk17122
+    and watchdog device /dev/watchdog2
+    `pcs stonith sbd enable device=/dev/disk/by-id/disk17111 device=/dev/disk/by-id/disk17122 watchdog=/dev/watchdog2`
+    4. Start the cluster
+    `pcs cluster start --all`
+    5. Create SBD fence agent named fencing-agent-sbd
+    `pcs stonith create fencing-agent-1 fence_sbd devices=/dev/disk/by-id/disk17111,/dev/disk/by-id/disk17122`
+  question: How to configure SBD fencing with two disks with ids /dev/disk/by-id/disk17111 and /dev/disk/by-id/disk17122
+    and fence agent with name fencing-agent-sbd and watchdog device /dev/watchdog2 in a running 2-node pacemaker cluster?
+task_description: 'Setup of SBD fencing method in a 2-node pacemaker cluster via pcs cli'


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

This skill helps with configuring various type of SBD fencing method in a 2-node pacemaker HA cluster via pcs cli.
First three seed examples gives step-by-step instructions on how to set up SBD fencing depending on entered type. The other 2 seed examples work with specific user values, the answer is generated with precise commands to set the desired configuration.


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   ...
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  ...
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] Contribution was tested with `lab generate`
- [ ] No errors or warnings were produced by `lab generate`
- [ ] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
