### PR TITLE
puns: re-order YAML keys for human legibility

### DIFF
--- a/compositional_skills/writing/freeform/jokes/puns/qna.yaml
+++ b/compositional_skills/writing/freeform/jokes/puns/qna.yaml
@@ -1,52 +1,52 @@
 created_by: mairin
 seed_examples:
-- answer: 'Why do birds eat wood?
+- question: Tell me a pun about birds.
+  answer: 'Why do birds eat wood?
 
 
     Because they''re peckish!
 
     '
-  question: Tell me a pun about birds.
-- answer: 'Why do French people always eat snails?
+- question: Tell me a pun about fast food.
+  answer: 'Why do French people always eat snails?
 
 
     They don''t like fast food.
 
     '
-  question: Tell me a pun about fast food.
-- answer: 'Why did the car have a belly ache?
+- question: Tell me a pun about gas.
+  answer: 'Why did the car have a belly ache?
 
 
     Because it had too much gas!
 
     '
-  question: Tell me a pun about gas.
-- answer: 'What did the ocean say to the ocean?
+- question: Tell me a pun about waves.
+  answer: 'What did the ocean say to the ocean?
 
 
     Nothing. It just waved!
 
     '
-  question: Tell me a pun about waves.
-- answer: 'Do you want to hear a roof joke?
+- question: Tell me a pun about roofs.
+  answer: 'Do you want to hear a roof joke?
 
 
     Nevermind. The first one''s on the house!
 
     '
-  question: Tell me a pun about roofs.
-- answer: 'What do dentists call their x-rays?
+- question: Tell me a pun about x-rays.
+  answer: 'What do dentists call their x-rays?
 
 
     Tooth pics!
 
     '
-  question: Tell me a pun about x-rays.
-- answer: 'Why does Peter Pan always fly?
+- question: Tell me a pun about Neverland.
+  answer: 'Why does Peter Pan always fly?
 
 
     Because he never lands.
 
     '
-  question: Tell me a pun about Neverland.
 task_description: ''


### PR DESCRIPTION
Questions typically precede answers, and joke punchlines normally come last. Re-order the question and answer keys in the canonical skill example to make them easier to parse/more natural for a human.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- this change is a computational no-op
- it aims only to improve human legibility

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] Contribution was tested with `lab generate`
- [ ] No errors or warnings were produced by `lab generate`
- [X] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [X] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
  - note: I have opted not to incorporate some lint suggestions into this PR wrt the string formatting of the answer values. The original pun author + whoever merged the file originally were satisfied with how they were presented.