### PR TITLE
Add skill of understanding rpm distribution tags

### DIFF
--- a/compositional_skills/extraction/information/rpm-distribution-tag/qna.yaml
+++ b/compositional_skills/extraction/information/rpm-distribution-tag/qna.yaml
@@ -1,0 +1,40 @@
+---
+task_description: Understanding of RPM distribution tags
+created_by: The-Mule
+seed_examples:
+  - question: |
+      What is the distribution tag of rpm package in RHEL-9?
+    answer: |
+      In all minor versions of RHEL-9 rpm packages have distribution
+      tag starting with "el9" where "el" stands for (Red Hat)
+      Enterprise Linux and "9" stands for major version 9.
+  - question: |
+      What is the distribution tag of rpm package in RHEL-8?
+    answer: |
+      In all minor versions of RHEL-8 rpm packages have distribution
+      tag starting "el8" where "el" stands for (Red Hat) Enterprise
+      Linux and "8" stands for major version 8.
+  - question: |
+      What is the distribution tag of rpm package in RHEL-7?
+    answer: |
+      In all minor versions of RHEL-8 rpm packages have distribution
+      tag starting with "el7" where "el" stands for (Red Hat) Enterprise
+      Linux and "7" stands for major version 7.
+  - question: |
+      What is the distribution tag of rpm package in Fedora 38?
+    answer: |
+      In all minor versions of RHEL-8 rpm packages have distribution
+      tag "fc38" where "fc" stands for Fedora Core and 38 for version
+      of Fedora.
+  - question: |
+      What is the distribution tag of libfido2-1.13.0-1.el8 package?
+    answer: |
+      Distribution tag is a part of RPM release. In this case release
+      is "1.el8" and hence the distribution tag of this package is
+      "el8" that stands for (Red Hat) Enterprise Linux 8.
+  - question: |
+      What is the distribution tag of libfido2-1.13.0-1.el9_1 package?
+    answer: |
+      Distribution tag is a part of RPM release. In this case release
+      is "1.el9_1" and hence the distribution tag of this package is
+      "el9_1" that stands for (Red Hat) Enterprise Linux 9.


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

This skill add understanding of distribution tag in rpm name. The distribution tag is part of rpm release field. Usually, it should be possible to tell what Linux RPM distribution a package is targeting from its distribution tag. The current model seems to understand RPM components ("NVR") quite well but it has issues understanding the meaning of distribution tag. This PR should help to correctly translate "el8", "el9", "fc38", ... and potentially it should be able to infer the meaning of future distribution tags such "fc40" or "el10".

**Input given at the prompt**

```
What is the distribution tag of libfido2-1.13.0-1.el9?
```

**Response that was received**

```
The distribution tag of libfido2-1.13.0-1.el9 is "el9." The distribution tag indicates the specific software distribution or platform that the package is intended for. In this case, "el9" likely stands for "Eligius 9," which is a software distribution or version. The exact meaning of "el9" may depend on the context in which it's used, such as in a package repository, software build system, or documentation. 
```

**Input given at the prompt**

```
What is the distribution tag of rpm packages in Fedora 40? 
```

**Response that was received**

```
Based on my knowledge up to date, Fedora 40 does not exist. The current version of Fedora is 38, which was released in May 2023. In Fedora, rpm packages typically use a distribution tag that includes the version number and a code for the distribution, such as "f38" for Fedora 38 or "el9" for Elasticsearch 9. To find out more about rpm packages in future versions or releases, I would recommend checking Fedora's official website or contacting their support team for the most accurate and up-to-date information. 
```

**Response that is now received instead**

I don't have the resources to train the model. But clearly it needs to reply Red Hat Enterprise Linux 9 instead of Eligius 9 and Elasticsearch 9 in the first and second answer, respectively.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] Contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)