### PR TITLE
Add qna schemas

### DIFF
--- a/.github/schemas/knowledge_schema.yaml
+++ b/.github/schemas/knowledge_schema.yaml
@@ -1,0 +1,7 @@
+seed_examples: list(include('seed'), min=5)
+task_description: str(min=1)
+domain: str(required=False)
+---
+seed:
+  answer: str(min=1)
+  question: str(min=1)

--- a/.github/schemas/skills_extraction_schema.yaml
+++ b/.github/schemas/skills_extraction_schema.yaml
@@ -1,0 +1,7 @@
+seed_examples: list(include('seed'), min=5)
+task_description: str(min=1)
+---
+seed:
+  answer: str(min=1)
+  context: str(min=1)
+  question: str(min=1)

--- a/.github/schemas/skills_freeform_schema.yaml
+++ b/.github/schemas/skills_freeform_schema.yaml
@@ -1,0 +1,7 @@
+seed_examples: list(include('seed'), min=5)
+task_description: str(min=1)
+---
+seed:
+  answer: str(min=1)
+  context: str(min=1,required=False)
+  question: str(min=1)

--- a/.github/schemas/skills_grounded_schema.yaml
+++ b/.github/schemas/skills_grounded_schema.yaml
@@ -1,0 +1,7 @@
+seed_examples: list(include('seed'), min=5)
+task_description: str(min=1)
+---
+seed:
+  answer: str(min=1)
+  context: str(min=1)
+  question: str(min=1)


### PR DESCRIPTION
This PR introduces [yamale](https://github.com/23andMe/Yamale) schemas for validating the various _qna documents_. As well as a CI workflow for running the validation dynamically on modified documents.

Running the validation manually:

```
$ pip install yamale

$ find knowledge/ \( -name '*.yaml' -or -name '*.yml' \) \
-exec yamale -s schemas/knowledge_schema.yaml {} \;

$ find compositional_skills/writing/freeform/ \( -name '*.yaml' -or -name '*.yml' \) \
-exec yamale -s schemas/skills_freeform_schema.yaml {} \;

$ find compositional_skills/writing/grounded/ \( -name '*.yaml' -or -name '*.yml' \) \
-exec yamale -s schemas/skills_grounded_schema.yaml {} \;

$ find compositional_skills/extraction/ \( -name '*.yaml' -or -name '*.yml' \) \
-exec yamale -s schemas/skills_extraction_schema.yaml {} \;
```

This overlaps with the shell commands in [lint.yaml](https://github.com/instruct-lab/taxonomy/blob/main/.github/workflows/lint.yml#L62), but I think it's a more robust and dynamic approach. The schemas can easily be expanded if necessary.

EDIT:
Added schema for extraction skills.

EDIT2:
Added [matcher](https://github.com/instruct-lab/taxonomy/pull/420/commits/a147167f408ae9ec5c0ed3c42d42492f344bf80f) for yamale errors.