### PR TITLE
README: Mention compute infrastructure as a fork cost

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,9 @@ This taxonomy repository will be used as the seed to synthesize the training dat
 
 By contributing your skills and knowledge to this repository, you will see your changes built into an LLM within days of your contribution rather than months or years! If you are working with a model and notice its knowledge or ability lacking, you could correct it by contributing knowledge or skills and check if it's improved once your changes are built.
 
+While public contributions are welcome to help drive community progress, you can also fork this repository under [the Apache License, Version 2.0](LICENSE), add your own internal skills, and train your own models internally.
+However, you may need your own access to significant compute infrastructure to perform sufficient retraining.
+
 ## Ways to Contribute
 
 You can contribute to the taxonomy in the following two ways: 


### PR DESCRIPTION
This section already started out with:

> The ability to contribute to a large language model (LLM) has been difficult in no small part because it is difficult to get access to the necessary compute infrastructure.

My new addition points out that that cost also applies to forks, to underline the value of things like centralized frequent model retraining.

And forking can dilute/fracture the community, so I'm also callling out the value of that community in sharing the
maintenance/contribution load.

But sometimes folks have work that they cannot upstream, either because it does not align with upstream-maintainer goals, or because they need to keep it internal.  My new paragraph points out that this is possible, but surrounds that possibility with reminders of the costs, so folks weighing those trade offs can make a more informed decision.

