### PR TITLE
ci: Require at least 5 seed_examples

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -42,7 +42,8 @@ following questionnaire with whatever information is applicable to your PR.
 
 <!-- Insert an x between the empty brackets: [ ] >> [x] -->
 
-- [ ] Contribution was tested with `lab generate`
+- [ ] The contribution was tested with `lab generate`
 - [ ] No errors or warnings were produced by `lab generate`
 - [ ] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
+- [ ] The `qna.yaml` file contains at least 5 `seed_examples`
 - [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,7 +79,7 @@ jobs:
             yq '.created_by       | length > 0'            $file | grep -q false && warn  "$(yq '.created_by|line'       $file):1: missing/empty 'created_by'"
             yq '.task_description | length > 0'            $file | grep -q false && warn  "$(yq '.task_description|line' $file):1: missing/empty 'task_description'"
             yq '.seed_examples'                            $file | grep -q null  && error "$(yq '.seed_examples|line'    $file):1: missing 'seed_examples'"
-            yq '.seed_examples   | length >= 3'            $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: less than 3 'seed_examples'"
+            yq '.seed_examples   | length >= 5'            $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: less than 5 'seed_examples'"
             yq '.seed_examples[] | .question | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'question's"
             yq '.seed_examples[] | .answer   | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'answer's"
             if $( yq '.seed_examples[] | has("context")'   $file | grep -q true ); then


### PR DESCRIPTION
As of 2024-03-12 the minimum number of seed examples has been increased from 3 to 5 in the most recent guidance from the approvers.
