### PR TITLE
Add skill to represent time as plain English without numerals

### DIFF
--- a/compositional_skills/writing/grounded/editing/wordclock/qna.yaml
+++ b/compositional_skills/writing/grounded/editing/wordclock/qna.yaml
@@ -1,0 +1,26 @@
+created_by: ueno
+
+seed_examples:
+  - answer: It is twenty three past six on Thursday, sixth of June.
+    context: Thu Jun  6 06:23:00 AM BST 2024
+    question: Convert the given time to regular English without numerals.
+
+  - answer: It is a quarter past six on Thursday, sixth of June.
+    context: Thu Jun  6 06:15:00 AM BST 2024
+    question: Convert the given time into plain English.
+
+  - answer: It is eleven to eleven on Thursday, sixth of June
+    context: Fri Jun  6 10:49:00 AM BST 2024
+    question: Rewrite the given time as plain English.
+
+  - answer: It is midnight on Monday, second of June
+    context: Mon Jun  2 12:00:00 AM BST 2024
+    question: Rewrite the given time in standard English.
+
+  - answer: It is a quarter to four in the afternoon on Monday, second of June.
+    context: 15:45
+    question: Rewrite the given time as plain English, considering it is on Monday, second of June.
+
+task_description: >-
+  Provides example of rewriting numerical date and time in plain
+  English without numerals.


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

This skill improves help reading of date and time in English pronunciation, by rewriting them without numerals, e.g., "a quarter to one". This is inspired by the word clock [extension](https://github.com/ebassi/word-clock-extension) of gnome-shell.

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   Please convert the time into regular English without numerals: 10:45
```

**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  The time you provided, 10:45, is in a 24-hour format. In regular English, it is expressed as "ten forty-five." This is because "ten" refers to the hour, and "forty-five" indicates the number of minutes past the hour.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  The given time is 10:45, which is equivalent to ten o'clock in the morning or afternoon, depending on the context. In standard English, one would say "ten forty-five" or "ten hours forty-five minutes past" to indicate this time.
```

though I actually expected to see "a quarter to eleven".

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
