### PR TITLE
added skill for updating dns servers via Ansible

### DIFF
--- a/compositional_skills/writing/freeform/technical/dns_settings/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/dns_settings/qna.yaml
@@ -1,7 +1,7 @@
 created_by: gdicks
 seed_examples:
   - answer: |
-      You can update a host's DNS settings with Ansible by using the `nmcli` module, which is the CLI for the NetworkManager utility that configures NICs, routes, VLAN's, DNS etc.
+      You can update a host's DNS settings with Ansible by using the `nmcli` module, which is the CLI for the NetworkManager utility that configures NICs, routes, VLANs, DNS etc.
 
       Here is a simple example playbook that uses the `nmcli` module:
 
@@ -33,7 +33,7 @@ seed_examples:
 
     question: How do I update a host's DNS settings using Ansible?
   - answer: |
-      You can update a host's DNS settings with Ansible by using the `nmcli` module, which is the CLI for the NetworkManager utility that configures NICs, routes, VLAN's, DNS etc.
+      You can update a host's DNS settings with Ansible by using the `nmcli` module, which is the CLI for the NetworkManager utility that configures NICs, routes, VLANs, DNS etc.
 
       Here is a simple example playbook that uses the `nmcli` module:
 

--- a/compositional_skills/writing/freeform/technical/dns_settings/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/dns_settings/qna.yaml
@@ -1,0 +1,67 @@
+created_by: gdicks
+seed_examples:
+  - answer: |
+      You can update a host's DNS settings with Ansible by using the `nmcli` module, which is the CLI for the NetworkManager utility that configures NICs, routes, VLAN's, DNS etc.
+
+      Here is a simple example playbook that uses the `nmcli` module:
+
+      ```yaml
+
+      ---
+      - name: "DNS server config updated"
+        hosts: my_hosts # replace with your ansible inventory
+
+        tasks:
+          - name: "DNS server set using nmcli"
+            nmcli:
+              conn_name: my_connection_name # replace with the name of the nmcli connection
+              type: ethernet
+              dns4:
+                - 192.168.53.53 # replace this with the IP address of your actual DNS server
+            state: present
+            notify: Restart NetworkManager
+
+        handlers:
+          - name: Restart NetworkManager
+            service:
+              name: NetworkManager
+              state: restarted
+      ```
+      The task described above applies the configuration for the ethernet connection specified by conn_name.
+      The IP address specified in the `dns4` key should be replaced by the IP address of your actual DNS server (in production environments ensure at least two DNS servers).
+      The playbook then invokes a handler, which uses the `service` module to restart the connection and activate the new DNS configuration.
+
+    question: How do I update a host's DNS settings using Ansible?
+  - answer: |
+      You can update a host's DNS settings with Ansible by using the `nmcli` module, which is the CLI for the NetworkManager utility that configures NICs, routes, VLAN's, DNS etc.
+
+      Here is a simple example playbook that uses the `nmcli` module:
+
+      ```yaml
+
+      ---
+      - name: "DNS server config updated"
+        hosts: my_hosts # replace with your ansible inventory
+
+        tasks:
+          - name: "DNS server set using nmcli"
+            nmcli:
+              conn_name: my_connection_name # replace with the name of the nmcli connection
+              type: ethernet
+              dns4:
+                - 192.168.53.53 # replace this with the IP address of your actual DNS server
+            state: present
+            notify: Restart NetworkManager
+
+        handlers:
+          - name: Restart NetworkManager
+            service:
+              name: NetworkManager
+              state: restarted
+      ```
+      The task described above applies the configuration for the ethernet connection specified by conn_name.
+      The IP address specified in the `dns4` key should be replaced by the IP address of your actual DNS server (in production environments ensure at least two DNS servers).
+      The playbook then invokes a handler, which uses the `service` module to restart the connection and activate the new DNS configuration.
+
+    question: How do I add a new DNS server in Linux using Ansible?
+task_description:


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Provides a simple Ansible playbook for updating DNS servers via Ansible
- The playbook uses the nmcli module to work at the network interface level
- A handler is also included to restart the network connection after config changes are applied


**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file contains at least 5 `seed_examples`
- [x ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
