### PR TITLE
Add skill to identify matching version of upstream project to product

### DIFF
--- a/compositional_skills/extraction/inference/quantitative/version_matching/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/version_matching/qna.yaml
@@ -1,0 +1,55 @@
+created_by: mchoma
+task_description: >-
+  This skill provides the ability to find version matching between upstream
+  project and downstream product
+seed_examples:
+  - context: |
+      JBoss EAP Version     WildFly Version
+      8.0     28
+      7.4     23
+      7.3     18
+      7.2     14
+      7.1     11
+      7.0     10
+    question: What Wildfly version is EAP 7.4 based on?
+    answer: EAP 7.4 is based on Wildfly 23.
+  - context: |
+      JBoss EAP Version     WildFly Version
+      8.0     28
+      7.4     23
+      7.3     18
+      7.2     14
+      7.1     11
+      7.0     10
+    question: What Wildfly version is EAP 7.3 based on?
+    answer: EAP 7.3 is based on Wildfly 18.
+  - context: |
+      JBoss EAP Version     WildFly Version
+      8.0     28
+      7.4     23
+      7.3     18
+      7.2     14
+      7.1     11
+      7.0     10
+    question: What Wildfly version is EAP 7.2 based on?
+    answer: EAP 7.2 is based on Wildfly 14.
+  - context: |
+      JBoss EAP Version     WildFly Version
+      8.0     28
+      7.4     23
+      7.3     18
+      7.2     14
+      7.1     11
+      7.0     10
+    question: What Wildfly version is EAP 7.1 based on?
+    answer: EAP 7.1 is based on Wildfly 11.
+  - context: |
+      JBoss EAP Version     WildFly Version
+      8.0     28
+      7.4     23
+      7.3     18
+      7.2     14
+      7.1     11
+      7.0     10
+    question: What Wildfly version is EAP 7.0 based on?
+    answer: EAP 7.0 is based on Wildfly 10.


### PR DESCRIPTION
Manifested on Wildfly project  to JBoss EAP product versioning schema


**Skill to identify matching version of upstream project to product**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Contribution improve model ability to match product version to project version on Wildfly vs. EAP example

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   What Wildfly version is EAP 7.4 based on?
```


**Response that was received**

<!-- What you received in response to your input, replace "..." -->

```
  Red Hat JBoss Enterprise Application Platform (EAP) 7.4 is based on WildFly 18, which was released in October 2019. EAP 7.4 is the latest version of the enterprise application platform from Red Hat, and it is built on top of the upstream WildFly project, incorporating many of the innovations and improvements from the community-driven distribution.
```


**Response that is now received instead**

<!-- What you receive with your contribution, replace "..." -->

```
  TODO. Running `lab generate`, `lab train`. Will get back once at the end.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
