### PR TITLE
Add generated files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,8 @@ scratch.ipynb
 
 # Ignore config.yaml from the cli
 config.yaml
+
+# Ignore generated training data
+generated_*
+test_*
+train_*


### PR DESCRIPTION
When you put a local taxonomy repo in the cli's config.yaml, the generated files are created in the git repo, but you're never going to want to commit them, so add their patterns to .gitignore.
