### PR TITLE
ci: Add GitHub Action to begin auto-labeling Pull Requests

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+documentation:
+- CODE_OF_CONDUCT.md
+- README.md
+- CONTRIBUTING.md
+- docs/**/*
+
+knowledge:
+- knowledge/**/*
+
+skill:
+- compositional_skills/**/*

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,9 +1,42 @@
+# Copyright The InstructLab Authors, 2024
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ci:
-- .github/workflows/**/*
-- .github/labeler.yml
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/scripts/**
+          - .github/workflows/**
+          - .github/*.yml
 
 documentation:
-- CODE_OF_CONDUCT.md
-- README.md
-- CONTRIBUTING.md
-- docs/**/*
+  - changed-files:
+      - any-glob-to-any-file:
+          - "*.md"
+          - docs/**
+
+knowledge:
+  - changed-files:
+      - any-glob-to-any-file:
+          - knowledge/**
+
+skill:
+  - changed-files:
+      - any-glob-to-any-file:
+          - compositional_skills/**
+
+triage-needed:
+  - changed-files:
+      - any-glob-to-any-file:
+          - compositional_skills/**
+          - knowledge/**

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,11 +1,9 @@
+ci:
+- .github/workflows/**/*
+- .github/labeler.yml
+
 documentation:
 - CODE_OF_CONDUCT.md
 - README.md
 - CONTRIBUTING.md
 - docs/**/*
-
-knowledge:
-- knowledge/**/*
-
-skill:
-- compositional_skills/**/*

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,13 @@
+name: labeler
+
+on:
+- pull_request_target
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/labeler@v5
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        sync-labels: true

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,10 +1,27 @@
-name: labeler
+# Copyright The InstructLab Authors, 2024
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: "Pull Request Labeler"
 
 on:
 - pull_request_target
 
 jobs:
-  label:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: actions/labeler@v5


### PR DESCRIPTION
This PR is designed to add rules that will auto-label PRs editing certain files defined in `labeler.yml`

Goal is to make it easier for maintainers to sort through Pull Requests, can be further enhanced/refined by adding new labels and files to the config

You can read more about this action here: https://github.com/actions/labeler