### PR TITLE
Fixes issue 471: match on a line that only contains null

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -78,7 +78,7 @@ jobs:
             fi
             yq '.created_by       | length > 0'            $file | grep -q false && warn  "$(yq '.created_by|line'       $file):1: missing/empty 'created_by'"
             yq '.task_description | length > 0'            $file | grep -q false && warn  "$(yq '.task_description|line' $file):1: missing/empty 'task_description'"
-            yq '.seed_examples'                            $file | grep -q null  && error "$(yq '.seed_examples|line'    $file):1: missing 'seed_examples'"
+            yq '.seed_examples'                            $file | grep -q '^null$'  && error "$(yq '.seed_examples|line'    $file):1: missing 'seed_examples'"
             yq '.seed_examples   | length >= 5'            $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: less than 5 'seed_examples'"
             yq '.seed_examples[] | .question | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'question's"
             yq '.seed_examples[] | .answer   | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'answer's"


### PR DESCRIPTION
Work in https://github.com/instruct-lab/taxonomy/pull/402 revealed that if the term null is in the qna yaml, the linter mistakenly thinks that seed_examples is missing.  This PR attempts to address https://github.com/instruct-lab/taxonomy/issues/471 by matching on a whole line that contains only null.

test demonstrating behavior after change:
```
$ yq .seed_examples compositional_skills/writing/grounded/openshift/installation/vsphere/staticip/qna.yaml | grep '^null$'
$ yq .seed_example compositional_skills/writing/grounded/openshift/installation/vsphere/staticip/qna.yaml |
 grep '^null$'
null
```