### PR TITLE
schema: We add attribution to the taxonomy schema

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -85,5 +85,8 @@ jobs:
             if $( yq '.seed_examples[] | has("context")'   $file | grep -q true ); then
               yq '.seed_examples[] | .context| length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'context's"
             fi
+            yq '.seed_examples[].attribution | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'attribution's"
+            yq '.seed_examples[].attribution[].source | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'attribution source's"
+            yq '.seed_examples[].attribution[].license | length > 0' $file | grep -q false && error "$(yq '.seed_examples|line'    $file):1: missing/empty 'attribution license's"
           done
           exit $ERR

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ answer pairs. The `qna.yaml` format should include the following fields:
 
 This example assumes the GitHub username `mairin`:
 
-``` yaml
+```yaml
 task_description: |
   The pun task enables the telling of funny pun-based jokes.
 created_by: mairin # Use your GitHub username; only one creator supported
@@ -51,21 +51,33 @@ seed_examples:
       Why do birds eat wood?
       
       Because they're peckish!
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
   - question: Tell me a pun about x-rays.
     answer: |
       What do dentists call their x-rays?
 
       Tooth pics!
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
   - question: Tell me a pun about gas.
     answer: |
       Why did the car have a belly ache?
 
       Because it had too much gas!
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
   - question: Tell me a pun about waves.
     answer: |
       What did the ocean say to the ocean?
 
       Nothing. It just waved!
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
 ```
 
 Seriously, that's it.
@@ -76,7 +88,7 @@ in terms of a taxonomy contribution:
 
 #### Freeform compositional skill: Directory tree example
 
-``` ascii
+```ascii
 [...]
 
 └── writing
@@ -99,7 +111,7 @@ Remember that [grounded compositional skills](https://github.com/instruct-lab/co
 
 This example assumes the GitHub username `mairin`:
 
-``` yaml
+```yaml
 task_description: | 
     This skill provides the ability to read a markdown-formatted table.
 created_by: mairin # Use your GitHub username; only one creator supported
@@ -115,6 +127,9 @@ seed_examples:
       Which breed has the most energy?
     answer: |
       The breed with the most energy is the Labrador.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
   - context: |
       | **Name** | **Date** | **Color** | **Letter** | **Number** |
       |----------|----------|-----------|------------|------------|
@@ -127,6 +142,9 @@ seed_examples:
       What is Gráinne's letter and what is her color?
     answer: |
       Gráinne's letter is B and her color is red.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
   - context: |
       | Banana | Apple      | Blueberry | Strawberry |
       |--------|------------|-----------|------------|
@@ -137,11 +155,14 @@ seed_examples:
       Which fruit is blue, small, and has no peel?
     answer: |
       The blueberry is blue, small, and has no peel.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
 ```
 
 #### Grounded compositional skill: Directory tree example
 
-``` ascii
+```ascii
 [...]
 
 └── extraction
@@ -185,7 +206,7 @@ pairs. The `qna.yaml` format should include the following fields:
 
 #### Knowledge: yaml example
 
-``` yaml
+```yaml
 task_description: |
   Knowledge about Taylor Swift's music.
 created_by: mairin   # Use your GitHub username; only one creator supported
@@ -197,6 +218,9 @@ seed_examples:
       the Gilette Stadium in Foxboro, MA for 3 nights from Friday May 19, 2023 
       to Sunday May 21, 2023. In 2024, she is making international tour stops 
       for her Eras tour outside of the United States.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
   - question: |
       Which album was released more recently, Reputation or Midnights?
     answer: |
@@ -206,14 +230,20 @@ seed_examples:
       Reputation called Reputation (Taylor's version) in the later half of 2024 
       which would make that the most recently-released album of the set at that 
       time.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
   - question: |
       Which album has the song "You Need to Calm Down?"
     answer: |
       The song "You Need to Calm Down" appears on Taylor Swift's 2019 album 
       Lover as track 14.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
 ```
 
-This knowledge references two markdown files: 
+This knowledge references two markdown files:
 `ts-world-tour-2024-schedule.md` as well as `ts-discography-2024.md` - these
 files in their entirety need to be submitted along with the knowledge's
 `qna.yaml` file in a `knowledge_documents` folder, which means that knowledge
@@ -226,7 +256,7 @@ pull requests are simpler and require less time and effort to review.
 What might these markdown files look like? They can be freeform. Here's what a
 snippet of `ts-discography-2024.md` might look like:
 
-``` markdown
+```markdown
 # Albums
 
 ## Studio Albums
@@ -263,7 +293,7 @@ referenced above might look like in the tree:
 
 #### Knowledge: directory tree example
 
-``` ascii
+```ascii
 [...]
 
 └── knowledge
@@ -289,42 +319,58 @@ referenced above might look like in the tree:
 
 ## YAML Format
 
-Taxonomy skill files can be any valid [YAML](https://yaml.org/) file ending in
-`.yaml` containing a set of key/value entries, in which the following three
-keys are recognized: `task_description`, `created_by`, and `seed_examples`.
+Taxonomy skill files can be any valid [YAML](https://yaml.org/) file named
+`qna.yaml` containing a set of key/value entries which contain the following keys:
 
-* The value of the `task_description` key can be any string.
-* The value of the `created_by` key can be any string.
-* The value of the `seed_examples` key is a collection of one or more key/value entries in which the
-three recognized keys are: `context`, `question`, and `answer`, each of which can have any string
-as value. For an entry to be valid, it **MUST** have the question and answer specified. 
+- `task_description` - A description of the skill. This key is required.
+
+- `created_by` - The GitHub username of the contributor. This key is required.
+
+- `seed_examples` - A collection of key/value entries which contain the following keys. This key is required.
+
+  - `question` - A question for the model. This key is required.
+
+  - `answer` The desired response from the model. This key is required.
+
+  - `context` - Grounded skills require the user to provide context containing information that the model is expected to take into account during processing. This is different from knowledge, where the model is expected to gain facts and background knowledge from the tuning process. The context key is optional for freeform skills.
+
+  - `attribution` - A collection of key/value entries which contain the following keys. All sources of information must be specified. This key is required.
+
+    - `source` - If information in the context, question, or answer come from a 3rd party, for example Wikipedia, then the value must specify a URL to the source material. If the contributor self-authored all the information, then the value must be `self-authored`. This key is required.
+
+    - `license` - The value must specify the [SPDX License Identifier](https://spdx.org/licenses/) of the source information. See [CONTRIBUTING.MD](./CONTRIBUTING.md#legal) for guidance on acceptable licenses for source information. If the information is self-authored, then `Apache-2.0` must be used. This key is required.
 
 Other keys at any level are currently ignored.
 
-To make these files easier and faster for humans to read, it is recommended to 
-specify the `task_description` first, followed by `created_by`, and finally 
-`seed_examples`. In `seed_examples`, it is recommended to specify the `context` 
-first (if applicable), followed by the `question`, and finally the `answer`.
+To make these files easier and faster for humans to read, it is recommended to
+specify `task_description` first, followed by `created_by`, and finally `seed_examples`.
+In `seed_examples`, it is recommended to specify `context`
+first (if applicable), followed by `question`, `answer`, and finally `attribution`.
 
 So in essence the format looks something like this:
 
-``` yaml
+```yaml
 task_description: <string>
 created_by: <string>
 seed_examples:
   - question: <string>
     answer: |
       <multi-line string>
+    attribution:
+      - source: <string>
+        license: <SPDX license identifier>
   - context: |
       <multi-line string>
     question: <string>
     answer: |
       <multi-line string>
+    attribution:
+      - source: <string>
+        license: <SPDX license identifier>
   ...  
 ```
 
-
-If you have not written YAML before, don't be intimidated - it's just text. 
+If you have not written YAML before, don't be intimidated - it's just text.
 There's a few things to know:
 
 - Spaces and indentation matter in YAML. Two spaces to indent.
@@ -344,7 +390,7 @@ tool. There is a very nice website you can use to do this:
 [yamllint.com](https://yamllint.com)
 
 You can copy/paste your YAML into the box and click the "Go" button to have it
-analyse your YAML and make recommendations.
+analyze your YAML and make recommendations.
 
 Online tools like [prettified](https://onlineyamltools.com/prettify-yaml) and
 [yaml-validator](https://jsonformatter.org/yaml-validator) can automatically
@@ -359,7 +405,7 @@ domain.
 
 Below is an illustrative directory structure to show this layout:
 
-``` ascii
+```ascii
 .
 └── writing
     ├── freeform
@@ -458,11 +504,12 @@ Below is an illustrative directory structure to show this layout:
                 └── one_line
                     └── qna.yaml
 ```
+
 ## Contribute knowledge and skills to the taxonomy!
 
 The ability to contribute to a large language model (LLM) has been difficult in no small part because it is difficult to get access to the necessary compute infrastructure.
 
-This taxonomy repository will be used as the seed to synthesize the training data for InstructLab-trained models. We intend to re-train the model(s) using the main branch following InstructLab's progressive training on a regular basis. This enables fast iteration of the model(s), for the benefit of the open source community. 
+This taxonomy repository will be used as the seed to synthesize the training data for InstructLab-trained models. We intend to re-train the model(s) using the main branch following InstructLab's progressive training on a regular basis. This enables fast iteration of the model(s), for the benefit of the open source community.
 
 By contributing your skills and knowledge to this repository, you will see your changes built into an LLM within days of your contribution rather than months or years! If you are working with a model and notice its knowledge or ability lacking, you could correct it by contributing knowledge or skills and check if it's improved once your changes are built.
 
@@ -471,41 +518,47 @@ However, you may need your own access to significant compute infrastructure to p
 
 ## Ways to Contribute
 
-You can contribute to the taxonomy in the following two ways: 
+You can contribute to the taxonomy in the following two ways:
 
-1. Adding new examples to **existing leaf nodes**: 
+1. Adding new examples to **existing leaf nodes**:
+
     - Go to the corresponding leaf node / end of the branch and modify the yaml 
     - Add new examples to the qna.yaml files as a new entry to the list
 
 2. Adding **new branches/skills** corresponding to the existing domain:
+
     - You can add new folders under the corresponding category (replace any spaces ` ` with underscores `_`)
     - Create a new qna.yaml file with examples for the new skill
   
 ### Detailed Contribution Instructions
 
-#### Pre-requisites:
+#### Pre-requisites
+
 - You need a GitHub account
 - You need access to this repo
 
 #### Make a copy of the taxonomy repo
 
 1. Go to [github.com/instruct-lab/taxonomy](https://github.com/instruct-lab/taxonomy)
+
 2. Press the Fork button in the upper right:
-   ![fork-button](https://github.com/instruct-lab/taxonomy/assets/799683/8487bff2-425e-483c-b27c-ef03da1c57a8)
+
+    ![fork-button](https://github.com/instruct-lab/taxonomy/assets/799683/8487bff2-425e-483c-b27c-ef03da1c57a8)
+
 3. On the "Create a new fork" form:
-   - **Repository name:** `taxonomy` is fine
-   - **Description:** This is the description of _your fork_, not of the skills you will create. You can write something that makes sense to you or leave it blank.
-   - **Copy the main branch only:** It's OK to leave this checked on.
+    - **Repository name:** `taxonomy` is fine
+    - **Description:** This is the description of _your fork_, not of the skills you will create. You can write something that makes sense to you or leave it blank.
+    - **Copy the main branch only:** It's OK to leave this checked on.
 
-When you are ready, press the **Create Fork** button.
+    When you are ready, press the **Create Fork** button.
 
-![Screenshot from 2024-02-28 12-41-59](https://github.com/instruct-lab/taxonomy/assets/799683/656608ef-3040-4858-96f0-9b695bea0e8f)
+    ![Screenshot from 2024-02-28 12-41-59](https://github.com/instruct-lab/taxonomy/assets/799683/656608ef-3040-4858-96f0-9b695bea0e8f)
 
 4. You will get a copy of the taxonomy repo in your github account. This is your own copy, so don't worry about making mistakes or anything like that. *(If you do end up making a mistake and want to start over: you can delete the fork and create a new fork.)*
 
 #### Contributing a skill
 
-In the screenshot, you can see we are under the compositional skills directory. This is the directory under which you want to contribute skills. (The other top-level directory you can contribute to is the knowledge directory, which is a little different than skills. You can read more about the difference between skills and knowledge [in that section of this README](#compositional-skills-vs-knowledge) above.) 
+In the screenshot, you can see we are under the compositional skills directory. This is the directory under which you want to contribute skills. (The other top-level directory you can contribute to is the knowledge directory, which is a little different than skills. You can read more about the difference between skills and knowledge [community documentation](https://github.com/instruct-lab/community/blob/main/docs/README.md).)
 
 ![Screenshot from 2024-02-28 12-44-05](https://github.com/instruct-lab/taxonomy/assets/799683/2038e035-5400-4848-91fb-f575db35b565)
 
@@ -527,12 +580,17 @@ Puns seemed to fit best under the freeform directory, but I didn't think they fi
 
 It can be a little tricky mechanically to create directories in GitHub's web UI:
 
-* Navigate to the folder in which you want to create the directory inside of.
-* Click the "Add File" dropdown button in the upper right corner of the screen.
-* Start typing the name of the first directory you want to create. In the animation below we use "jokes/" as the first directory. 
-* When you type the "/" character, the directory name will "lock in" and you'll be able to type the next of the next subdirectory under it, as desired. Below we typed "knock-knock/" as the next directory name.
-* Make sure to replace any spaces (` `) in the folder name with underscores (`_`)
-* Finally, you'll type the file name. The file name should always be qna.yaml. (qna stands for "Question aNd Answer.")  
+- Navigate to the folder in which you want to create the directory inside of.
+
+- Click the "Add File" dropdown button in the upper right corner of the screen.
+
+- Start typing the name of the first directory you want to create. In the animation below we use "jokes/" as the first directory.
+
+- When you type the "/" character, the directory name will "lock in" and you'll be able to type the next of the next subdirectory under it, as desired. Below we typed "knock-knock/" as the next directory name.
+
+- Make sure to replace any spaces (` `) in the folder name with underscores (`_`)
+
+- Finally, you'll type the file name. The file name should always be qna.yaml. (qna stands for "Question aNd Answer.")
 
 Here's an animated graphic to show how it works:
 
@@ -542,7 +600,7 @@ Here's an animated graphic to show how it works:
 
 ### How should I contribute?
 
-For additional information on how to make a contribution, please, consult the 
+For additional information on how to make a contribution, please, consult the
 [documentation on contributing](CONTRIBUTING.md).
 
 ### Why should I contribute?


### PR DESCRIPTION
All examples must contain an attribution key. The lint check is updated to test for the presence of the attribution key and its subkeys.

attribution is an array of mappings where each mapping has a source and license key. source is a URL to 3rd party information or `self-authored` if the contributor authored the information. license is the SPDX license identifier of the 3rd party information or `Apache-2.0` (repo license) if the contributor authored the information.

Fixes https://github.com/instruct-lab/taxonomy/issues/182