### PR TITLE
Add 'os' section of libvirt VM XML generation skill

### DIFF
--- a/compositional_skills/writing/freeform/technical/virtualization/libvirt_xml/os_booting/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/virtualization/libvirt_xml/os_booting/qna.yaml
@@ -1,0 +1,72 @@
+task_description: |
+  This task is used to generate 'os' section of libvirt VM XML configuration
+created_by: weizhan
+seed_examples:
+  - question: >-
+      Generate 'os' section of a libvirt VM XML configuration with default
+      firmware, serial console and SMBIOS
+    answer: |
+      <os>
+        <type>hvm</type>
+        <boot dev='cdrom'/>
+        <bootmenu enable='yes' timeout='3000'/>
+        <smbios mode='sysinfo'/>
+        <bios useserial='yes' rebootTimeout='0'/>
+      </os>
+  - question: >-
+      Generate 'os' section of a libvirt VM XML configuration with UEFI manual
+      firmware and secure boot
+    answer: |
+      <os>
+        <type>hvm</type>
+        <loader readonly='yes' secure='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>
+        <nvram template='/usr/share/OVMF/OVMF_VARS.fd'>/var/lib/libvirt/nvram/guest_VARS.fd</nvram>
+        <boot dev='hd'/>
+      </os>
+  - question: >-
+      Generate 'os' section of a libvirt VM XML configuration with UEFI manual
+      firmware and secure boot and with NVRAM type 'file'
+    answer: |
+      <os>
+        <type>hvm</type>
+        <loader readonly='yes' secure='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>
+        <nvram type='file' template='/usr/share/OVMF/OVMF_VARS.fd'>
+          <source file='/var/lib/libvirt/nvram/guest_VARS.fd'/>
+        </nvram>
+        <boot dev='hd'/>
+      </os>
+  - question: >-
+      Generate 'os' section of a libvirt VM XML configuration with UEFI manual
+      firmware and secure boot and with network backed NVRAM'
+    answer: |
+      <os>
+        <type>hvm</type>
+        <loader readonly='yes' secure='yes' type='pflash'>/usr/share/OVMF/OVMF_CODE.fd</loader>
+        <nvram type='network'>
+          <source protocol='iscsi' name='iqn.2013-07.com.example:iscsi-nopool/0'>
+            <host name='example.com' port='6000'/>
+            <auth username='myname'>
+              <secret type='iscsi' usage='mycluster_myname'/>
+            </auth>
+          </source>
+        </nvram>
+        <boot dev='hd'/>
+      </os>
+  - question: >-
+      Generate 'os' section of a libvirt VM XML configuration with automatic
+      UEFI firmware and secure boot
+    answer: |
+      <os firmware='efi'>
+        <type>hvm</type>
+        <loader secure='yes'/>
+        <boot dev='hd'/>
+      </os>
+  - question: >-
+      Generate 'os' section of a libvirt VM XML configuration with automatic
+      UEFI stateless firmware for AMD SEV
+    answer: |
+      <os firmware='efi'>
+        <type>hvm</type>
+        <loader stateless='yes'/>
+        <boot dev='hd'/>
+      </os>


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Add 'os' section of libvirt VM XML generation skill


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   Generate 'os' section of a libvirt VM XML configuration with xxx
```


**Response from the original model**


<!-- What you received from the original model in response to your input, 
replace "..." -->

```
<os> 
<type>hvm</type> 
<boot dev='hd'/>
<uuid>[UUID]</uuid>
<version>2</version>
<loader>
<type>uefi</type>
<mode>manual</mode>
<secure>yes</secure>
</loader>
<vcpus>
<model>intel-xen</model>
</vcpus>
</os> 
```


**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
Hope to be 
      <os>
        <type>hvm</type>
        <boot dev='cdrom'/>
        <bootmenu enable='yes' timeout='3000'/>
        <smbios mode='sysinfo'/>
        <bios useserial='yes' rebootTimeout='0'/>
      </os>

lab generate very slow so still waiting....
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] The contribution was tested with `lab generate`
- [ ] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
