### PR TITLE
Add a skill to find missing people in a meeting

### DIFF
--- a/compositional_skills/extraction/inference/quantitative/missing_people/qna.yaml
+++ b/compositional_skills/extraction/inference/quantitative/missing_people/qna.yaml
@@ -1,0 +1,29 @@
+task_description: |
+  This task can help to list the names who are missing in a meeting.
+created_by: pezhang
+seed_examples:
+  - question: >-
+      Today's meeting is important. We should have Lily, Lucy, Tom, Tim, David
+      and John here, we only see Lily, Lucy, David and John here, tell me who
+      are missing?
+    answer: Tom and Tim are missing.
+  - question: >-
+      We should have Lily, Lucy, Tom, Tim, David and John in today's meeting, we
+      only see Lily, Lucy, David and John here, tell me who are missing?
+    answer: Tom and Tim are missing.
+  - question: >-
+      We should have Lily, Lucy, Tom, Tim, David and John in today's meeting, we
+      only see Lily, Lucy, Tom, David and John here, tell me who are missing?
+    answer: Tim is missing.
+  - question: >-
+      Lily, Lucy, Tom, Tim, David and John should attend today's meeting, but we
+      only see Tom, Tim, David and John here, tell me who are missing?
+    answer: Lily and Lucy are missing.
+  - question: >-
+      We should have Lily, Lucy, Tom, Tim, David and John in today's meeting, we
+      only see Lily, Lucy, Tom and David here, tell me who are missing?
+    answer: Tim and John is missing.
+  - question: >-
+      We should have Lily, Lucy, Tom, Tim, David and Pei attending this meeting,
+      we only see David, Pei, Tom and Tim here, tell me who are missing?
+    answer: Licy and Lucy are missing.


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.

**Describe the contribution to the taxonomy**

The current model cannot list all the people who are missing in a meeting.
For example if there are 3 people missing, the model can only list one or two people.

**Input given at the prompt**

We should have Lily, Lucy, Tom, Tim, David and Pei attending this meeting,we only see David, Pei, Tom and Tim here, tell me who are missing?


**Response from the original model**

│ #### In the meeting today, we expected to see Lily, Lucy, Tom, Tim, David, and Pei. However, we only see David, Pei, Tom, and Tim present  │
│ at the moment. Therefore, the individual who is currently missing from the meeting is:                                                     │
│                                                                                                                                            │
│ 1. #### Lucy: She was expected to be present in the meeting but is currently absent.   

**Response from the fine-tuned model**

We expect (still training in progress):
Lily and Lucy are missing.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)

Note: `lab generate` output:
INFO 2024-03-14 01:17:55,921 generate_data.py:373 Generation took 5958.84s
