### PR TITLE
 Improve answers related to OCSP validation path and request numbers

### DIFF
--- a/compositional_skills/writing/freeform/technical/pki/ocsp/qna.yaml
+++ b/compositional_skills/writing/freeform/technical/pki/ocsp/qna.yaml
@@ -1,0 +1,143 @@
+task_description: >
+  The OCSP validation task enables the answers to OCSP validation related
+  questions in the case when OCSP Stapling is not enabled, specifically in the
+  area of validation path and the number of OCSP requests encurred at each
+  certificate validation. The Root CA's immediate subordinate CA is considered
+  level 1 intermediate CA, whereas the subordinate CA of the level 1 subordinate
+  CA is considered level 2 subordinate CA, etc.
+created_by: ladycfu
+seed_examples:
+  - question: >-
+      In an environment where OCSP Stapling is not enabled, if certificate C is
+      issued by a level 1 subordinate CA, what is the maximum number of OCSP
+      responses that could potentially be received from the OCSP responder?
+    answer: >
+      If certificate C is issued by a level 1 subordinate CA, the maximum number
+      of OCSP responses that could potentially be received from the OCSP
+      responder is 3. This is because, a level 1 subordinate CA has 2 CA signing
+      certificates in its chain, including the root CA, so when OCSP Stapling is
+      not enabled, if OCSP is enabled, and all certs in chain contain an AIA
+      extension, one OCSP request will be sent for the leaf certificate, and
+      another 2 OCSP requests will be sent for the CAs in the chain. Therefore,
+      there are 1+2=3 potential OCSP responses in total. It is worth noting that
+      the root CA signing cert, being a self-signed cert, is a trust anchor and
+      often time does not contain an AIA so in which case it would not trigger
+      any OCSP responses. If OCSP caching is enabled, the number of OCSP
+      responses received will be reduced, depending on whether the last OCSP
+      response for certificate C, or the CAs in its chain are still in the cache
+      or not.
+  - question: >-
+      In an environment where OCSP Stapling is not enabled, if certificate C is
+      issued by a level 2 subordinate CA, what is the maximum number of OCSP
+      responses that could potentially be received from the OCSP responder?
+    answer: >
+      If certificate C is issued by a level 2 subordinate CA, the maximum number
+      of OCSP responses that could potentially be received from the OCSP
+      responder is 4. This is because, a level 2 subordinate CA has 3 CA signing
+      certificates in its chain, including the root CA, so when OCSP Stapling is
+      not enabled, if OCSP is enabled, and all certs in chain contain an AIA
+      extension, one OCSP request will be sent for the leaf certificate, and
+      another 3 OCSP requests will be sent for the CAs in the chain. Therefore,
+      there are 1+3=4 potential OCSP responses in total. It is worth noting that
+      the root CA signing cert, being a self-signed cert, is a trust anchor and
+      often time does not contain an AIA so in which case it would not trigger
+      any OCSP responses. If OCSP caching is enabled, the number of OCSP
+      responses received will be reduced, depending on whether the last OCSP
+      response for certificate C, or the CAs in its chain are still in the cache
+      or not.
+  - question: >-
+      In an environment where OCSP Stapling is not enabled, if certificate C is
+      issued by a level 3 subordinate CA, what is the maximum number of OCSP
+      responses that could potentially be received from the OCSP responder?
+    answer: >
+      If certificate C is issued by a level 3 subordinate CA, the maximum number
+      of OCSP responses that could potentially be received from the OCSP
+      responder is 5. This is because, a level 3 subordinate CA has 4 CA signing
+      certificates in its chain, including the root CA, so when OCSP Stapling is
+      not enabled, if OCSP is enabled, and all certs in chain contain an AIA
+      extension, one OCSP request will be sent for the leaf certificate, and
+      another 4 OCSP requests will be sent for the CAs in the chain. Therefore,
+      there are 1+4=5 potential OCSP responses in total. It is worth noting that
+      the root CA signing cert, being a self-signed cert, is a trust anchor and
+      often time does not contain an AIA so in which case it would not trigger
+      any OCSP responses. If OCSP caching is enabled, the number of OCSP
+      responses received will be reduced, depending on whether the last OCSP
+      response for certificate C, or the CAs in its chain are still in the cache
+      or not.
+  - question: >-
+      In an environment where OCSP Stapling is not enabled, if certificate C is
+      issued by a level 4 subordinate CA, what is the maximum number of OCSP
+      responses that could potentially be received from the OCSP responder?
+    answer: >
+      If certificate C is issued by a level 4 subordinate CA, the maximum number
+      of OCSP responses that could potentially be received from the OCSP
+      responder is 6. This is because, a level 4 subordinate CA has 5 CA signing
+      certificates in its chain, including the root CA, so when OCSP Stapling is
+      not enabled, if OCSP is enabled, and all certs in chain contain an AIA
+      extension, one OCSP request will be sent for the leaf certificate, and
+      another 5 OCSP requests will be sent for the CAs in the chain. Therefore,
+      there are 1+5=6 potential OCSP responses in total. It is worth noting that
+      the root CA signing cert, being a self-signed cert, is a trust anchor and
+      often time does not contain an AIA so in which case it would not trigger
+      any OCSP responses. If OCSP caching is enabled, the number of OCSP
+      responses received will be reduced, depending on whether the last OCSP
+      response for certificate C, or the CAs in its chain are still in the cache
+      or not.
+  - question: >-
+      In an environment where OCSP Stapling is not enabled, if certificate C is
+      issued by a root CA, what is the maximum number of OCSP responses that
+      could potentially be received from the OCSP responder?
+    answer: >
+      If certificate C is issued by a a root CA, the maximum number of OCSP
+      responses that could potentially be received from the OCSP responder is 2.
+      This is because, a root CA has 1 signing certificate in its chain, so when
+      OCSP Stapling is not enabled, if OCSP is enabled, and all certs in chain
+      contain an AIA extension, one OCSP request will be sent for the leaf
+      certificate, and another 1 OCSP request will be sent for the CAs in the
+      chain. Therefore, there are 1+1=2 potential OCSP responses in total. It is
+      worth noting that the root CA signing cert, being a self-signed cert, is a
+      trust anchor and often time does not contain an AIA so in which case it
+      would not trigger any OCSP responses. If OCSP caching is enabled, the
+      number of OCSP responses received will be reduced, depending on whether
+      the last OCSP response for certificate C, or the CAs in its chain are
+      still in the cache or not.
+  - question: >-
+      consider a CA hierarchy where certificate C is issued by a level 1
+      subordinate CA. What is the maximum number of OCSP responses that could
+      potentially be received from the OCSP responder if OCSP Stapling is not
+      enabled and OCSP is enabled for all certs in the chain?
+    answer: >
+      If certificate C is issued by a level 1 subordinate CA, the maximum number
+      of OCSP responses that could potentially be received from the OCSP
+      responder is 3. This is because, a level 1 subordinate CA has 2 CA signing
+      certificates in its chain, including the root CA, so when OCSP Stapling is
+      not enabled, if OCSP is enabled, and all certs in chain contain an AIA
+      extension, one OCSP request will be sent for the leaf certificate, and
+      another 2 OCSP requests will be sent for the CAs in the chain. Therefore,
+      there are 1+2=3 potential OCSP responses in total. It is worth noting that
+      the root CA signing cert, being a self-signed cert, is a trust anchor and
+      often time does not contain an AIA so in which case it would not trigger
+      any OCSP responses. If OCSP caching is enabled, the number of OCSP
+      responses received will be reduced, depending on whether the last OCSP
+      response for certificate C, or the CAs in its chain are still in the cache
+      or not.
+  - question: >-
+      consider a CA hierarchy where certificate C is issued by a level 2
+      subordinate CA. What is the maximum number of OCSP responses that could
+      potentially be received from the OCSP responder if OCSP Stapling is not
+      enabled and OCSP is enabled for all certs in the chain?
+    answer: >
+      If certificate C is issued by a level 2 subordinate CA, the maximum number
+      of OCSP responses that could potentially be received from the OCSP
+      responder is 4. This is because, a level 2 subordinate CA has 3 CA signing
+      certificates in its chain, including the root CA, so when OCSP Stapling is
+      not enabled, if OCSP is enabled, and all certs in chain contain an AIA
+      extension, one OCSP request will be sent for the leaf certificate, and
+      another 3 OCSP requests will be sent for the CAs in the chain. Therefore,
+      there are 1+3=4 potential OCSP responses in total. It is worth noting that
+      the root CA signing cert, being a self-signed cert, is a trust anchor and
+      often time does not contain an AIA so in which case it would not trigger
+      any OCSP responses. If OCSP caching is enabled, the number of OCSP
+      responses received will be reduced, depending on whether the last OCSP
+      response for certificate C, or the CAs in its chain are still in the cache
+      or not.


### PR DESCRIPTION
    The OCSP validation task enables the answers to OCSP validation related questions in the case when OCSP Stapling is not enabled.
    
    This initial patch answers questions specifically in the area of validation path and the number of OCSP requests encurred at each certificate validation. There is an assumption that the root CA's immediate subordinate CA is considered level 1 intermediate CA, whereas the subordinate CA of the level 1 subordinate CA is considered level 2 subordinate CA, etc.
    
    ------------------------------
    Results prior to this patch:
    ------------------------------
    question:
    In an environment where OCSP Stapling is not enabled, if certificate C is issued by a level 1 subordinate CA, what is the maximum number of OCSP responses that could potentially be received from the OCSP responder?
    
    answer:
    In an environment where OCSP Stapling is not enabled, the maximum number of OCSP responses that could potentially be received from the OCSP responder for certificate C would depend on the specific configuration of the CA hierarchy and the OCSCP responder. However, in the scenario described where certificate C is issued by a level 1 subordinate CA, the maximum number of OCSP responses would likely be one. This is because the level 1 subordinate CA would typically only have one OCSP response for its own certificate, which would then be used to validate the certificates of any end entities it has issued certificates to, such as certificate C. If there were multiple OCSP responses for the level 1 subordinate CA, it would likely be due to the CA having multiple certificates, but this would still only result in one OCSP response for each end entity certificate that the CA has issued
    
    my observation/analysis:
    The answer above is incorrect. OCSP Stapling is not at play so for a cert issued by a level 1 subordinate CA would likely cause the following certs to be validated: leaf, level 1 sub CA, and root CA. So the maximum number is 3.
    
    ----
    
    Question:
    In an environment where OCSP Stapling is not at play, if certificate C is issued by a level 2 subordinate CA, how many OCSP responses could potentially be received from the OCSP responder?
    
    Answer:
    If certificate C is issued by a level 2 subordinate CA in an environment where OCSP Stapling is not at play, there would still only be one OCSP response generated for this certificate. The OCSP responder would generate the response based on the revocation status of certificate C and its     dependencies, which include the level 2 subordinate CA certificate and,
    ultimately, the root CA certificate. The maximum number of OCSP responses in this case remains one, as the OCSP responder would only provide information about the certificate status for certificate C, its direct dependencies, and their transitive dependencies, up to the root CA certificate. This ensures that the OCSP responder maintains up-to-date information about the certificate's status, allowing certificate validators to make informed decisions about trust and security.
    
    my observation/analysis:
    The answer above is incorrect. OCSP Stapling is not at play so for a cert issued by a level 2 subordinate CA would likely cause the following certs to be validated: leaf, level 2 sub CA, level 1 sub CA, and root CA. So the maximum number is 4.
    
    ----
    Question:
    In an environment where OCSP Stapling is not at play, if certificate C is issued by a level 3 subordinate CA, how many OCSP responses could potentially be received from the OCSP responder?
    
    Answer:
    In this scenario, where OCSP Stapling is not in use, and certificate C is issued by a level 3 subordinate CA, there would still only be one OCSP   response generated for this certificate. The OCSP responder would generate the response based on the revocation status of certificate C and its  dependencies, which include the level 3 subordinate CA certificate and,   ultimately, the root CA certificate. The maximum number of OCSP responses in this case remains one, as the OCSP responder would only provide information about the certificate status for certificate C, its direct dependencies, and their transitive dependencies, up to the root CA certificate. This ensures that the OCSP responder maintains up-to-date information about the certificate's status, allowing certificate validators to make informed decisions about trust and security.
    
    my observation/analysis:
    The answer above is incorrect. OCSP Stapling is not at play so for a cert issued by a level 3 subordinate CA would likely cause the following certs to be validated: leaf, level 1 sub CA, level 2 sub CA, level 3 sub CA, and root CA. So the maximum number is 5.
    
    ------------------------
    Results after my patch:
    ------------------------
    Question:
    In a PKI environment where OCSP Stapling is not enabled, if certificate C is issued by a level 1 subordinate CA, what is the maximum number of OCSP responses that could potentially be received from the OCSP responder when OCSP is enabled for all certs in the chain?
    
    Answer:
    If certificate C is issued by a level 1 subordinate CA, the maximum number of OCSP responses that could potentially be received from the OCSP responder when OCSP is enabled for all certs in the chain is 3. This is because, a level 1 subordinate CA has 2 CA signing certificates in its chain, including the root CA, so when OCSP Stapling is not enabled, if OCSP is enabled, and all certs in chain contain an AIA extension, one OCSP request will be sent for the leaf certificate, and another 2 OCSP requests will be sent for the CAs in the chain. Therefore, there are 1+2=3 potential OCSP responses in total. It is worth noting that the root CA signing cert, being a self-signed cert, is a trust anchor and often time does not contain an AIA so in which case it would not trigger any OCSP responses. If OCSP caching is enabled, the number of OCSP responses received will be reduced, depending on whether the last OCSP response for certificate C, or the CAs in its chain are still in the cache or not.
    
    ----
    Question:
    Consider a PKI environment where OCSP Stapling is not enabled, and OCSP is enabled for all certificates in the chain. What is the maximum number of OCSP responses that could potentially be received from the OCSP responder if the certificate is issued by a level 3 subordinate CA?
    
    Answer:
    If the certificate is issued by a level 3 subordinate CA, the maximum number of OCSP responses that could potentially be received from the OCSP responder is 5. This is because, a level 3 subordinate CA has 4 CA signing certificates in its chain, including the root CA, so when OCSP Stapling is not enabled, if OCSP is enabled for all certs in the chain, one OCSP request will be sent for the leaf certificate, and another 4 OCSP requests will be sent for the CAs in the chain. Therefore, there are 1+4=5 potential OCSP responses in total. It is worth noting that the root CA signing cert, being a self-signed cert, is a trust anchor and often time does not contain an AIA so in which case it would not trigger any OCSP responses. If OCSP caching is enabled, the number of OCSP responses received will be reduced, depending on whether the last OCSP response for the certificate, or the CAs in its chain are still in the cache or not.

If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- ...
- ...
- ...


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   ...
```


**Response from the original model**


<!-- What you received from the original model in response to your input, 
replace "..." -->

```
  ...
```


**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
  ...
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
