### PR TITLE
feat: date conversion between calendars

### DIFF
--- a/compositional_skills/conversion/calendar/qna.yaml
+++ b/compositional_skills/conversion/calendar/qna.yaml
@@ -1,0 +1,21 @@
+created_by: saberkan
+seed_examples:
+  - answer: >-
+      15th March 2024 in gregorian calendar correspends to 5th Ramadan 1445 in
+      arabic calendar
+    question: convert 15th March 2024 from gregorian calendar into arabic calendar
+  - answer: >-
+      4th July 1998 from gregorian calendar matchs 11th Tamuz 5750 in hebrew
+      calendar
+    question: convert 4th July 1990 from gregorian calendar into hebrew calendar
+  - answer: 1st April 1543 from gregorian calendar correspends to 11th Farvardin 922
+    question: convert 1st April 1543 from gregorian calendar into persian calendar
+  - answer: >-
+      11th Farvardin 922 from persian calendar correspends to 1st April 1543 in
+      gregorian calendar
+    question: convert 11th Farvardin 922 from persian calendar into gregorian calendar
+  - answer: >-
+      15th Tishri 4511 from hebrew calendar correspends to 14th Safar 133 in
+      arabic calendar
+    question: convert 15th Tishri 4511 from hebrew calendar into arabic calendar
+task_description: Date conversion between calendars


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- This feature makes the model more accurate when it comes to date conversion between different calendars.

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
convert the following 15 march 2024 from gregorian calendar into arabic calendar
```


**Response from the original model**


<!-- What you received from the original model in response to your input, 
replace "..." -->

```
  ╭─────────────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ────────────────────────────────────────────────────────────────────╮
│ The date you provided, March 15, 2024, is not within the current leap year (1444 AH) in the Arabic (Hijri) calendar, which spans from July 8, 2022, to     │
│ July 6, 2023. Therefore, I cannot directly convert this date to the Arabic calendar. However, I can help you convert it to the Gregorian calendar for the  │
│ next leap year in the Arabic calendar, which begins on July 8, 2033, and ends on July 6, 2034.                                                             │
│                                                                                                                                                            │
│ To convert March 15, 2024, to the Arabic calendar for the next leap year, you would need to consider the following:                                        │
│                                                                                                                                                            │
│ 1. The start date of the next leap year in the Arabic calendar is July 8, 2033 (1 Muharram 1435 AH).                                                       │
│ 2. The number of days elapsed between March 1                                                                                                              │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 33.471 seconds ─╯

```


**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
 1436 AH (arabic calendar)
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)