### PR TITLE
chore: added yamale schemas for the various qna document types

### DIFF
--- a/.github/schemas/knowledge_schema.yaml
+++ b/.github/schemas/knowledge_schema.yaml
@@ -1,0 +1,7 @@
+seed_examples: list(include('seed'), min=5)
+task_description: str(min=1)
+domain: str(required=False)
+---
+seed:
+  answer: str(min=1)
+  question: str(min=1)

--- a/.github/schemas/skills_extraction_schema.yaml
+++ b/.github/schemas/skills_extraction_schema.yaml
@@ -1,0 +1,7 @@
+seed_examples: list(include('seed'), min=5)
+task_description: str(min=1)
+---
+seed:
+  answer: str(min=1)
+  context: str(min=1)
+  question: str(min=1)

--- a/.github/schemas/skills_freeform_schema.yaml
+++ b/.github/schemas/skills_freeform_schema.yaml
@@ -1,0 +1,7 @@
+seed_examples: list(include('seed'), min=5)
+task_description: str(min=1)
+---
+seed:
+  answer: str(min=1)
+  context: str(min=1,required=False)
+  question: str(min=1)

--- a/.github/schemas/skills_grounded_schema.yaml
+++ b/.github/schemas/skills_grounded_schema.yaml
@@ -1,0 +1,7 @@
+seed_examples: list(include('seed'), min=5)
+task_description: str(min=1)
+---
+seed:
+  answer: str(min=1)
+  context: str(min=1)
+  question: str(min=1)


### PR DESCRIPTION
This PR introduces [yamale](https://github.com/23andMe/Yamale) schemas for validating the various _qna documents_.

Running the validation manually:

```
$ pip install yamale

$ find knowledge/ \( -name '*.yaml' -or -name '*.yml' \) \
-exec yamale -s .github/schemas/knowledge_schema.yaml {} \;

$ find compositional_skills/writing/freeform/ \( -name '*.yaml' -or -name '*.yml' \) \
-exec yamale -s .github/schemas/skills_freeform_schema.yaml {} \;

$ find compositional_skills/writing/grounded/ \( -name '*.yaml' -or -name '*.yml' \) \
-exec yamale -s .github/schemas/skills_grounded_schema.yaml {} \;

$ find compositional_skills/extraction/ \( -name '*.yaml' -or -name '*.yml' \) \
-exec yamale -s .github/schemas/skills_extraction_schema.yaml {} \;
```

Original PR: https://github.com/instruct-lab/taxonomy/pull/420