### PR TITLE
chore: added editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = false
+tab_width = 4
+
+[*.{yaml,yml}]
+trim_trailing_whitespace = true
+
+[*.sh]
+indent_size = 4
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab
+indent_size = 4
+
+[*.puml]
+indent_size = unset


### PR DESCRIPTION
Added [editorconfig](https://editorconfig.org/) to maintain consistent writing styles.
Most editors either have a built-in plugin or a downloadable one for editorconfig. Scroll down to the tool's page for a list of editors and plugins.

Validating outputs inconsistent styles in existing documents:

```shell
$ go run github.com/editorconfig-checker/editorconfig-checker/v2/cmd/editorconfig-checker@latest

.github/ISSUE_TEMPLATE/bug_report.md:
        25: Wrong amount of left-padding spaces(want multiple of 2)
.github/ISSUE_TEMPLATE/proposal.md:
        23: Wrong amount of left-padding spaces(want multiple of 2)
.github/pull_request_template.md:
        20: Wrong amount of left-padding spaces(want multiple of 2)
CODE_OF_CONDUCT.md:
        26: Wrong amount of left-padding spaces(want multiple of 2)
        30: Wrong amount of left-padding spaces(want multiple of 2)
        32: Wrong amount of left-padding spaces(want multiple of 2)
LICENSE:
        2: Wrong amount of left-padding spaces(want multiple of 2)
        3: Wrong amount of left-padding spaces(want multiple of 2)
        6: Wrong amount of left-padding spaces(want multiple of 2)
        8: Wrong amount of left-padding spaces(want multiple of 2)
        67: Wrong amount of left-padding spaces(want multiple of 2)
        74: Wrong amount of left-padding spaces(want multiple of 2)
        90: Wrong amount of left-padding spaces(want multiple of 2)
        131: Wrong amount of left-padding spaces(want multiple of 2)
        139: Wrong amount of left-padding spaces(want multiple of 2)
        144: Wrong amount of left-padding spaces(want multiple of 2)
        154: Wrong amount of left-padding spaces(want multiple of 2)
        166: Wrong amount of left-padding spaces(want multiple of 2)
        177: Wrong amount of left-padding spaces(want multiple of 2)
        179: Wrong amount of left-padding spaces(want multiple of 2)
        190: Wrong amount of left-padding spaces(want multiple of 2)
        192: Wrong amount of left-padding spaces(want multiple of 2)
        193: Wrong amount of left-padding spaces(want multiple of 2)
        194: Wrong amount of left-padding spaces(want multiple of 2)
        196: Wrong amount of left-padding spaces(want multiple of 2)
        198: Wrong amount of left-padding spaces(want multiple of 2)
        199: Wrong amount of left-padding spaces(want multiple of 2)
        200: Wrong amount of left-padding spaces(want multiple of 2)
        201: Wrong amount of left-padding spaces(want multiple of 2)
        202: Wrong amount of left-padding spaces(want multiple of 2)
docs/README.md:
        Wrong line endings or no final newline
docs/review-process.puml:
        Wrong line endings or no final newline

32 errors found
```

a _precommit_ hook can be found [here](https://github.com/editorconfig-checker/editorconfig-checker.python?tab=readme-ov-file#usage-with-the-pre-commit-git-hooks-framework).