### PR TITLE
Skill: Recognize when statements are referring to the same place.

### DIFF
--- a/compositional_skills/extraction/inference/qualitative/places/qna.yaml
+++ b/compositional_skills/extraction/inference/qualitative/places/qna.yaml
@@ -1,0 +1,71 @@
+task_description: |
+  Recognize when statements are referring to the same place.  I.e., if m
+  different statements are made about a given space having n things, then the
+  total number of things in the space is n and not m*n.
+created_by: anfredette
+seed_examples:
+  - question: |
+      Bob has two dogs. Each dog lives with three cats. How many cats does
+      Bob live with?
+    answer: |
+      Bob lives with 3 cats. If each of Bob's two dogs lives with three cats,
+      and these cats are shared among the dogs rather than being unique to each
+      dog, then Bob lives with 3 cats in total.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: |
+      Alice and Bob live together. Alice lives with 2 dogs. Bob lives with two
+      dogs. How many dogs are in the house?
+    answer: |
+      There are two dogs in the house. If Alice and Bob live together, and Alice
+      lives with 2 dogs while Bob also lives with 2 dogs, but they are sharing
+      the same living space, it means they collectively have 2 dogs in the
+      house, not 4, since the description implies they are counting the same
+      dogs.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: |
+      Andrew and Ben work in the same office building. Andrew's office building
+      has two conference rooms. Ben's office building has two conference rooms.
+      What is the total number of conference rooms in the building?
+    answer: |
+      There are two conference rooms in the office building. If Andrew and
+      Ben work in the same office building, and the information about the number
+      of conference rooms is given for both Andrew's and Ben's office building,
+      we're actually talking about the same building. Therefore, the total
+      number of conference rooms in the building is two.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: |
+      Brooke lives with three cats. Alice lives with Brooke. How many cats does
+      Alice live with??
+    answer: |
+      Alice lives with three cats. If Brooke has three cats and Alice lives with
+      Brooke, then Alice lives with three cats as well.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: |
+      Andrew and Bob live on the same street. There are two stop signs on Bob's
+      street. There are two stop signs on Andrew's street. How many stop signs
+      are there?
+    answer: |
+      There are a total of two stop signs on the street. If Andrew and Bob live
+      on the same street, and both statements refer to this street having two
+      stop signs, then there are a total of two stop signs on the street.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - question: |
+      Brooke lives with three cats. Alice lives with three cats. Alice and
+      Brooke live together in the same house. How many cats are in the house?
+    answer: |
+      If Brooke and Alice live together in the same house and both statements
+      about living with three cats refer to the same group of cats, then there
+      are a total of three cats in the house.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

This skill was inspired by the contribution by @russellb (https://github.com/instruct-lab/taxonomy/pull/365). It occurred to me
that there were other similar situations in which something was shared that
should be recognized.

In general, recognizing when statements are referring to the same place. I.e.,
if m different statements are made about a given space having n things, then 
the total number of things in the space is n and not m*n.

For example, if I ask the question "Brooke lives with three cats. Alice lives
with Brooke. How many cats does Alice live with?"  The model recognizes that
they live together, and responds that Alice lives with 3 cats as expected.

However, if I ask the similar question "Brooke lives with three cats. Alice
lives with three cats. Alice and Brooke live together in the same house. How
many cats are in the house?" The model does not infer that we are talking about
the same three cats and responds with 3+3=6 cats.

I have asked several similar questions (see `qna.yaml` file for a selection) and
in all cases the response is similar to the unexpected response above.

I initially trained the model with the `qna.yaml` from pr #365 to see if it
would help, but it didn't. I then tried retraining with both the file from pr
#365 as well as my new `qna.yaml` file, but that didn't help. So, to reduce the
number of variables, I trained the model with only my file, but that didn't help
either. I also tried a couple different ways to word my answers but those also
didn't help.

The main difference after retraining with my new questions and answers seems to
be that the model answers with the same incorrect answer, but with a more
verbose justification.

Unfortunately, my attempts to train the model were not successful. However, I
am submitting this as a draft in case it provides some useful information or if
anyone has suggestions for how to train the model better.

I was curious about whether these questions were reasonable, so I asked them to ChatGPT. 
In all cases, ChatGPT responded with the answers that I was expecting with a good
explanation of the rationale.

Two examples are given below.

**Input given at the prompt**

```
  Q1:
  Andrew and Bob live on the same street. There are two stop signs on Bob's
  street. There are two stop signs on Andrew's street. How many stop signs are
  there?
```

```
  Q2:
  Alice and Bob live together. Alice lives with 2 dogs. Bob lives with two dogs.
  How many dogs are in the house?
```

**Response from the original model**

```
  A1:
  There are two stop signs for each of the two people, so there are 2 x 2 = 4
  stop signs in total. The answer is 4
```

```
  A2:
  Alice and Bob each have 2 dogs, so between them, they have 2 dogs + 2 dogs = 4
  dogs. Since they live together, there are 4 dogs in the house.
```

**Response from the fine-tuned model**

```
  A1':
  The statement mentions that Andrew and Bob live on the same street, but it
  does not specify the number of stop signs on Andrew's street directly. To find
  out the number of stop signs on Andrew's street, we need to add the number of
  stop signs on Bob's street (2) to the number of stop signs on Andrew's street
  (2), resulting in four stop signs in total that Andrew and Bob live on the
  same street. Therefore, there are four stop signs on Andrew's street.
```

```
  A2':
  The statement mentions that Alice and Bob live together and Alice lives with 2
  dogs, while Bob lives with two dogs as well. To find out how many dogs are in
  the house, we need to add the number of dogs Alice lives with (2) to the
  number of dogs Bob lives with (2), resulting in four dogs in total in the
  house. Therefore, there are four dogs in the house.
```

**Contribution checklist**

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
