### PR TITLE
ASCII progress bar skill

### DIFF
--- a/compositional_skills/writing/freeform/ascii_art/progressbar/qna.yaml
+++ b/compositional_skills/writing/freeform/ascii_art/progressbar/qna.yaml
@@ -1,0 +1,13 @@
+created_by: cau-git
+seed_examples:
+- answer: '[=============================>--------------------] 60%'
+  question: Print an ASCII progress bar with 60% progress.
+- answer: '[--------------------------------------------------]  0%'
+  question: Print an ASCII progress bar with 0% progress.
+- answer: '[==================================================] 100%'
+  question: Print an ASCII progress bar with 100% progress.
+- answer: '[==========>---------------------------------------] 20%'
+  question: Print an ASCII progress bar with 20% progress.
+- answer: '[==================================================]=========> 120%'
+  question: Print an ASCII progress bar with 120% progress.
+task_description: ''

--- a/compositional_skills/writing/freeform/ascii_art/progressbar/qna.yaml
+++ b/compositional_skills/writing/freeform/ascii_art/progressbar/qna.yaml
@@ -28,4 +28,3 @@ seed_examples:
         license: Apache-2.0
 task_description: Output ASCII-style progress bar with a specified percentage
   straight at the users request, without python code generation.
-

--- a/compositional_skills/writing/freeform/ascii_art/progressbar/qna.yaml
+++ b/compositional_skills/writing/freeform/ascii_art/progressbar/qna.yaml
@@ -1,13 +1,31 @@
+---
 created_by: cau-git
 seed_examples:
-- answer: '[=============================>--------------------] 60%'
-  question: Print an ASCII progress bar with 60% progress.
-- answer: '[--------------------------------------------------]  0%'
-  question: Print an ASCII progress bar with 0% progress.
-- answer: '[==================================================] 100%'
-  question: Print an ASCII progress bar with 100% progress.
-- answer: '[==========>---------------------------------------] 20%'
-  question: Print an ASCII progress bar with 20% progress.
-- answer: '[==================================================]=========> 120%'
-  question: Print an ASCII progress bar with 120% progress.
-task_description: ''
+  - answer: "[=============================>--------------------] 60%"
+    question: Print an ASCII progress bar with 60% progress.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - answer: "[--------------------------------------------------]  0%"
+    question: Print an ASCII progress bar with 0% progress.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - answer: "[==================================================] 100%"
+    question: Print an ASCII progress bar with 100% progress.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - answer: "[==========>---------------------------------------] 20%"
+    question: Print an ASCII progress bar with 20% progress.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+  - answer: "[==================================================]=========> 120%"
+    question: Print an ASCII progress bar with 120% progress.
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+task_description: Output ASCII-style progress bar with a specified percentage
+  straight at the users request, without python code generation.
+

--- a/compositional_skills/writing/freeform/ascii_art/progressbar/qna.yaml
+++ b/compositional_skills/writing/freeform/ascii_art/progressbar/qna.yaml
@@ -1,30 +1,30 @@
----
 created_by: cau-git
 seed_examples:
-  - answer: "[=============================>--------------------] 60%"
+  - answer: '[=============================>--------------------] 60%'
     question: Print an ASCII progress bar with 60% progress.
     attribution:
       - source: self-authored
         license: Apache-2.0
-  - answer: "[--------------------------------------------------]  0%"
+  - answer: '[--------------------------------------------------]  0%'
     question: Print an ASCII progress bar with 0% progress.
     attribution:
       - source: self-authored
         license: Apache-2.0
-  - answer: "[==================================================] 100%"
+  - answer: '[==================================================] 100%'
     question: Print an ASCII progress bar with 100% progress.
     attribution:
       - source: self-authored
         license: Apache-2.0
-  - answer: "[==========>---------------------------------------] 20%"
+  - answer: '[==========>---------------------------------------] 20%'
     question: Print an ASCII progress bar with 20% progress.
     attribution:
       - source: self-authored
         license: Apache-2.0
-  - answer: "[==================================================]=========> 120%"
+  - answer: '[==================================================]=========> 120%'
     question: Print an ASCII progress bar with 120% progress.
     attribution:
       - source: self-authored
         license: Apache-2.0
-task_description: Output ASCII-style progress bar with a specified percentage
-  straight at the users request, without python code generation.
+task_description: >-
+  Output ASCII-style progress bar with a specified percentage straight at the
+  users request, without python code generation.


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Adds a skill to output ASCII-style progress bar with a specified percentage straight.
- Avoid receiving python code that allegedly produces the requested output, and bad predictions of what that code would output.


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
   Print an ASCII progress bar with 60% progress.
```


**Response from the original model**

The model will always produce python code, no matter how it is asked for the progress bar. The output the model claims to be produced out of the provided python code is sometimes correct, sometimes wrong (see example below).

<!-- What you received from the original model in response to your input, 
replace "..." -->

> ```python                                                                  
> def print_progress_bar(percentage):                                        
>    filled_length = int(percentage)                                        
>    bar = '=' * filled_length + '>' * (10 - filled_length)                 
>    percents = "[{bar}{percents}] {percentage:2.0f} %".format(bar=bar,     
> percents=' ' * (28 - len(bar)), percentage=percentage)                     
>     print(percents, end="\r")                                              
>                                                                            
> print_progress_bar(60)                                                     
> ```                                                                        
> This version of the script provides more context for the progress bar,     
> including the percentage in front of the bar, instead of just after the bar
> as in the previous example. The progress bar will be printed as:           
>                                                                            
> [=======|>         40 %                                                    


**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
  TBD - no training possible on Intel Mac.
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `lab generate`
- [X] No errors or warnings were produced by `lab generate`
- [X] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [X] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
