### PR TITLE
Skill: semantic version comparison and filtering

### DIFF
--- a/compositional_skills/extraction/version_comparison/qna.yaml
+++ b/compositional_skills/extraction/version_comparison/qna.yaml
@@ -1,0 +1,446 @@
+task_description: 'Version string comparison skill'
+created_by: 'TomasHofman'
+seed_examples:
+  - question: |
+      Order following list of versions from highest to lowest:
+
+      14.3.5
+      6.14.8-GA
+      7.4.3
+      11.8.6
+      6.14.8
+      6.14.8-CR3
+      6.14.8-Beta
+      6.14.8.CR1
+      6.13.7
+    answer: |
+      Here is the list with version strings ordered from highest to lowest:
+
+      14.3.5
+      11.8.6
+      7.4.3
+      6.14.8-GA
+      6.14.8
+      6.14.8-CR3
+      6.14.8.CR1
+      6.14.8-Beta
+      6.13.7
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from highest to lowest:
+
+      7.13.2
+      10.12.3
+      11.1.6.CR3
+      11.1.6-CR2
+      10.7.11
+      11.1.6-Beta
+      3.5.9
+      11.1.6
+      11.1.6-CR1
+    answer: |
+      Here is the list with version strings ordered from highest to lowest:
+
+      11.1.6
+      11.1.6.CR3
+      11.1.6-CR2
+      11.1.6-CR1
+      11.1.6-Beta
+      10.12.3
+      10.7.11
+      7.13.2
+      3.5.9
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from highest to lowest:
+
+      4.6.6
+      4.6.6-Alpha
+      4.6.6-Final
+      4.6.6-CR2
+      2.11.8
+      11.14.5
+      4.6.6.CR3
+      4.14.14
+      4.12.10
+    answer: |
+      Here is the list with version strings ordered from highest to lowest:
+
+      11.14.5
+      4.14.14
+      4.12.10
+      4.6.6
+      4.6.6-Final
+      4.6.6.CR3
+      4.6.6-CR2
+      4.6.6-Alpha
+      2.11.8
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from highest to lowest:
+
+      12.1.10
+      7.14.1.GA
+      9.5.12
+      7.14.1-Beta
+      7.14.1
+      5.2.2
+      7.14.1.Alpha
+      2.7.12
+      7.14.1.CR2
+    answer: |
+      Here is the list with version strings ordered from highest to lowest:
+
+      12.1.10
+      9.5.12
+      7.14.1.GA
+      7.14.1
+      7.14.1.CR2
+      7.14.1-Beta
+      7.14.1.Alpha
+      5.2.2
+      2.7.12
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from highest to lowest:
+
+      11.13.11
+      11.1.9-CR3
+      4.8.1
+      11.1.9.GA
+      11.1.9-Alpha
+      11.1.9.CR2
+      11.1.9
+      2.2.10
+      3.9.3
+    answer: |
+      Here is the list with version strings ordered from highest to lowest:
+
+      11.13.11
+      11.1.9.GA
+      11.1.9
+      11.1.9-CR3
+      11.1.9.CR2
+      11.1.9-Alpha
+      4.8.1
+      3.9.3
+      2.2.10
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from lowest to highest:
+
+      13.10.9
+      10.3.3
+      3.2.5
+      3.6.1
+      3.2.5-Beta
+      13.1.7
+      3.2.5-Final
+      3.2.5-CR3
+      3.2.5-Alpha
+    answer: |
+      Here is the list with version strings ordered from lowest to highest:
+
+      3.2.5-Alpha
+      3.2.5-Beta
+      3.2.5-CR3
+      3.2.5
+      3.2.5-Final
+      3.6.1
+      10.3.3
+      13.1.7
+      13.10.9
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from lowest to highest:
+
+      14.5.9.CR2
+      14.5.9
+      14.5.9-Alpha
+      14.5.9.CR3
+      1.1.2
+      13.13.14
+      10.13.5
+      14.5.9-Beta
+      9.9.11
+    answer: |
+      Here is the list with version strings ordered from lowest to highest:
+
+      1.1.2
+      9.9.11
+      10.13.5
+      13.13.14
+      14.5.9-Alpha
+      14.5.9-Beta
+      14.5.9.CR2
+      14.5.9.CR3
+      14.5.9
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from lowest to highest:
+
+      6.11.10.Final
+      6.11.10-CR3
+      13.1.4
+      5.4.14
+      6.11.10
+      6.11.10.Alpha
+      6.11.10-CR2
+      4.7.12
+      13.6.2
+    answer: |
+      Here is the list with version strings ordered from lowest to highest:
+
+      4.7.12
+      5.4.14
+      6.11.10.Alpha
+      6.11.10-CR2
+      6.11.10-CR3
+      6.11.10.Final
+      6.11.10
+      13.1.4
+      13.6.2
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from lowest to highest:
+
+      12.14.10
+      11.8.14
+      12.14.10-CR3
+      12.14.10.Final
+      12.14.10-Beta
+      4.7.5
+      14.5.4
+      2.13.3
+      12.14.10.Alpha
+    answer: |
+      Here is the list with version strings ordered from lowest to highest:
+
+      2.13.3
+      4.7.5
+      11.8.14
+      12.14.10.Alpha
+      12.14.10-Beta
+      12.14.10-CR3
+      12.14.10
+      12.14.10.Final
+      14.5.4
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Order following list of versions from lowest to highest:
+
+      6.4.3-CR1
+      6.4.3.Final
+      10.10.8
+      9.4.3
+      6.4.3.Alpha
+      6.5.9
+      8.7.6
+      6.4.3
+      6.4.3-GA
+    answer: |
+      Here is the list with version strings ordered from lowest to highest:
+
+      6.4.3.Alpha
+      6.4.3-CR1
+      6.4.3.Final
+      6.4.3
+      6.4.3-GA
+      6.5.9
+      8.7.6
+      9.4.3
+      10.10.8
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Select versions that belong to major version 3.x:
+
+      36.7.1
+      2.9.8
+      3.7.5
+      7.5.7
+      12.13.8
+      8.11.13
+      3.7.2.Final
+      3.12.4
+    answer: |
+      Here is the list with version strings that belong to major version 3.x:
+
+      3.7.2.Final
+      3.7.5
+      3.12.4
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Select versions that belong to major version 8.x:
+
+      6.7.3
+      8.10.1.Final
+      8.9.3
+      10.10.2
+      8.4.1
+      5.5.7
+      85.2.1
+      1.12.5
+    answer: |
+      Here is the list with version strings that belong to major version 8.x:
+
+      8.4.1
+      8.9.3
+      8.10.1.Final
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Select versions that belong to major version 3:
+
+      12.6.8
+      3.10.3
+      10.9.8
+      39.10.1
+      3.3.5.Final
+      3.2.13
+      2.13.1
+      8.10.5
+    answer: |
+      Here is the list with version strings that belong to major version 3:
+
+      3.2.13
+      3.3.5.Final
+      3.10.3
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Select versions that belong to major version 9:
+
+      9.12.2
+      14.2.11
+      13.5.13
+      2.8.3
+      93.3.6
+      9.9.7
+      8.11.14
+      9.1.10.Final
+    answer: |
+      Here is the list with version strings that belong to major version 9:
+
+      9.1.10.Final
+      9.9.7
+      9.12.2
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Select versions that belong to minor version 13.12.x:
+
+      1.8.7
+      4.13.2
+      13.12.3
+      8.11.4
+      13.12.9
+      14.11.13
+      13.12.7
+    answer: |
+      Here is the list with version strings that belong to minor version 13.12.x:
+
+      13.12.3
+      13.12.7
+      13.12.9
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Select versions that belong to minor version 14.13.x:
+
+      14.13.9
+      5.4.2
+      14.13.4
+      14.13.6
+      3.11.11
+      10.11.2
+      7.13.8
+    answer: |
+      Here is the list with version strings that belong to minor version 14.13.x:
+
+      14.13.4
+      14.13.6
+      14.13.9
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Select versions that belong to minor version 12.2:
+
+      13.10.1
+      12.2.5
+      13.12.14
+      8.11.3
+      9.1.9
+      12.2.10
+      12.2.7
+    answer: |
+      Here is the list with version strings that belong to minor version 12.2:
+
+      12.2.5
+      12.2.7
+      12.2.10
+    attribution:
+      - source: self-authored
+        license: Apache-2.0
+
+  - question: |
+      Select versions that belong to minor version 2.10:
+
+      14.6.8
+      3.14.1
+      2.10.10
+      2.10.1
+      2.10.6
+      1.2.8
+      10.3.3
+    answer: |
+      Here is the list with version strings that belong to minor version 2.10:
+
+      2.10.1
+      2.10.6
+      2.10.10
+    attribution:
+      - source: self-authored
+        license: Apache-2.0


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

Improves filtering and ordering of versions strings.

**Input given at the prompt**

```
>>> Print version strings from following list that belong to major version 1.x:

    2.0.1
    3.0.6
    1.5.6
    1.0.8
    0.3.1
    11.0.0
    0.128.3.6
```

```
>>> Order following version strings from lowest to highest:
 
    2.0.1
    3.0.6
    1.5.6
    1.0.8
    0.3.1
    11.0.0
    0.128.3.6
 ```

**Response from the original model**

```
╭─────
│ Here is the list with version strings that belong to major version 1.x:  
│ 1.0.8                                                                    
│ 11.0.0                                                                   
╰─────
```
(Wrong version included.)

```
╭─────
│ Here is the list with version strings ordered from lowest to highest: 
 |
│ 0.128.3.6
│ 0.3.1
│ 1.0.8
│ 1.5.6
│ 2.0.1
│ 11.0.0
╰─────
```
(Version 3.0.6 is missing.)


**Response from the fine-tuned model**

Not able to do the training on my HW.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
