### PR TITLE
Add a skill about temperature of objects staying higher after use

### DIFF
--- a/compositional_skills/extraction/inference/qualitative/temperature/qna.yaml
+++ b/compositional_skills/extraction/inference/qualitative/temperature/qna.yaml
@@ -1,0 +1,83 @@
+task_description: 'various cases when higher temperature helps identify what happened before'
+created_by: hhorak
+
+seed_examples:
+- context: |
+    There are 3 light bulbs in the room, and none of them is shining. One of
+    the bulbs was just switched off after it was turned on for an hour.
+  question: |
+    How do I know which bulb was turned on recently?
+  answer: |
+    I can carefully put my finger on all bulbs and sense the temperature.
+    Since the bulb gets hot when turned on and the temperature decreases
+    slowly, the bulb which was turned on recently will have the highest
+    temperature.
+  attribution:
+    - source: self-authored
+      license: Apache-2.0
+
+- context: |
+    There are 10 cars in the garage. One of them just parked a minute ago
+    after driving for 2 hours.
+  question: |
+    How can I tell which car it was?
+  answer: |
+    When a car goes on a street, several parts change temperature and get warm.
+    The engine of the car gets warm because there are small explosions inside.
+    Other parts get warm because of friction between parts or between wheels
+    and the tarmac.
+    So, one way to tell which car was driving recently is to open the hood
+    and carefully touch the engine. If the engine is warm then it is the car
+    that was driving recently.
+    Another way is to carefully touch the tires. When a car is going fast,
+    the tires get warm, so the car that has warm tires is most likely the one
+    that was driving recently.
+  attribution:
+    - source: self-authored
+      license: Apache-2.0
+
+- context: |
+    There are 8 chairs in a meeting room. 3 people just finished a meeting
+    that took an hour.
+  question: |
+    How can I tell where the people were sitting?
+  answer: |
+    When a person sits on a chair, the chair gets warmer. So, one way to tell
+    which chair was occupied recently is to touch the chair and feel
+    the temperature.
+    The three chairs that are the warmest are likely those where the three
+    people were sitting.
+  attribution:
+    - source: self-authored
+      license: Apache-2.0
+
+- context: |
+    There are several toilets in the lavatory in the office. One colleague just
+    left the lavatory.
+  question: |
+    How can I tell which toilet the person just used?
+  answer: |
+    When a person sits on a toilet, the toilet gets a bit warmer from the
+    human's body. Thus, one way to tell which toilet was occupied a minute ago
+    is to carefully touch the toilet seat and consider the temperature.
+    The warmest toilet seat is the one that the person most likely was
+    sitting on.
+  attribution:
+    - source: self-authored
+      license: Apache-2.0
+
+- context: |
+    There are 10 beers on a table. Some are on the table for several hours
+    already. Some were just brought to the table by a waiter.
+  question: |
+    How can one tell which beer is fresh?
+  answer: |
+    When a beer is served, it is mostly cold. When a beer says on a table
+    for an hour, the beer gets warmer because of the warm air around.
+    When a person wants to pick the beer that is fresh, the person can
+    touch the glass of the table and the beers which the lowest temperature
+    is most likely the fresh one.
+  attribution:
+    - source: self-authored
+      license: Apache-2.0
+


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- the model did not respond properly when asked about effect of usage of some object on its temperature
- this new skill adds common cases where people would not have problem to answer on how to figure out which of the objects moved/were turned on recently


**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
There are 3 light bulbs in a room, none of them is shining. One of the bulb was just switched off after it was turned on for an hour. how do I know which one it was?
```


**Response from the original model**


<!-- What you received from the original model in response to your input, 
replace "..." -->

``` 
╭───────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ──────────────────────────────────────────────────────────────╮
│ Determining which light bulb was switched off among several identical bulbs in a room can be challenging without additional clues or context,  │
│ especially if all bulbs were off before being turned on for a brief period. However, there are some possible methods to identify the inactive  │
│ bulb after it has been turned on:                                                                                                              │
│                                                                                                                                                │
│ 1. **Visual inspection:** After turning on all bulbs, wait for some time (preferably in the same hour) for them to reach their full            │
│ brightness. Then, turn off one bulb and inspect them visually one-by-one. The bulb that was turned off might appear slightly dimmer or darker  │
│ compared to the active bulbs. This method is more effective if there is a significant difference in brightness between the bulbs.              │
│                                                                                                                                                │
│ 2. **Temperature differences:** If the bulbs have different power ratings or ages, they might draw different amounts of current or generate    │
│ different levels of heat. By feeling the bulbs, you might be able to identify the inactive bulb if it feels cooler or warmer than the others   │
│ after being turned off. However, this method requires careful handling and attention to detail.                                                │
│                                                                                                                                                │
│ 3. **Multimeter or test equipment:** Using a multimeter or other test equipment, you can measure the voltage or current passing through each   │
│ bulb before and after turning one off. By comparing the readings, you can identify the bulb that was switched off. This method requires access │
│ to appropriate test equipment and some level of electrical knowledge.                                                                          │
│                                                                                                                                                │
│ 4. **Switching on/off:** By turning each bulb on and off, you can compare the visual or physical changes between the bulbs to identify the one │
│ that was switched off after being turned on for an hour. This method requires careful observation and patience, as it involves manipulating    │
│ each bulb individually.                                                                                                                        │
│                                                                                                                                                │
│ In summary, identifying a specific light bulb that was switched off among several identical bulbs can be challenging without additional clues  │
│ or context, especially if all bulbs were off before being turned on for a brief period. Visual inspection, temperature differences, test       │
│ equipment, or switching on/off are some possible methods to identify the inactive bulb, but they all require careful attention and             │
│ observation.                                                                                                                                   │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 81.959 seconds ─╯
```


**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
╭───────────────────────────────────────────────────────────── merlinite-7b-Q4_K_M ──────────────────────────────────────────────────────────────╮
│ To determine which light bulb was recently switched off, you can perform the following steps:                                                  │
│                                                                                                                                                │
│ 1. Observe the light bulbs: Examine the light bulbs individually to see if any of them have cooled down more than the others. A recently       │
│ switched-off bulb might still be warm or cooler than the other bulbs that have been off for a longer time.                                     │
│                                                                                                                                                │
│ 2. Check the power outlet: Inspect the power outlet that the light bulb was connected to. If the recently switched-off bulb was the only one   │
│ using that outlet, it might still be warm or have residual heat compared to the other outlets.                                                 │
│                                                                                                                                                │
│ 3. Compare the brightness: If you have access to a brightness meter or a smartphone app that can measure brightness, compare the brightness    │
│ levels of the light bulbs. The recently switched-off bulb might still have a higher brightness level than the other bulbs that have been off   │
│ for a longer time.                                                                                                                             │
│                                                                                                                                                │
│ 4. Use a thermal camera: If you have access to a thermal camera or an infrared thermometer, you can measure the temperature of each light      │
│ bulb. The recently switched-off bulb might still have a higher temperature than the other bulbs that have been off for a longer time.          │
│                                                                                                                                                │
│ 5. Check the light bulb wattage: If the light bulbs have different wattages, the recently switched-off bulb might have consumed more energy    │
│ than the other bulbs that have been off for a longer time. Compare the wattage ratings of the light bulbs to see if there is a difference.     │
│                                                                                                                                                │
│ By following these steps, you can increase the likelihood of determining which light bulb was recently switched off. However, it's important   │
│ to note that these methods might not always provide a definitive answer, especially if the other bulbs have been off for a long time or if     │
│ they have similar wattages and temperatures.                                                                                                   │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 89.574 seconds ─╯

```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
