### PR TITLE
Prepare for knowledge submissions

### DIFF
--- a/.github/schemas/v1/knowledge.json
+++ b/.github/schemas/v1/knowledge.json
@@ -7,7 +7,8 @@
         "created_by",
         "domain",
         "task_description",
-        "seed_examples"
+        "seed_examples",
+        "document"
     ],
     "unevaluatedProperties": false,
     "properties": {
@@ -48,6 +49,47 @@
                         "description": "The desired response for the question.",
                         "type": "string",
                         "minLength": 1
+                    }
+                }
+            }
+        },
+        "document": {
+            "description": "The knowledge documents.",
+            "type": "object",
+            "required": [
+                "repo",
+                "commit",
+                "pattern"
+            ],
+            "unevaluatedProperties": false,
+            "properties": {
+                "repo": {
+                    "description": "The URL to a Git repository holding the knowledge documents.",
+                    "type": "string",
+                    "minLength": 1,
+                    "examples": [
+                        "https://github.com/instruct-lab/cli"
+                    ]
+                },
+                "commit": {
+                    "description": "The commit in the Git repository containing the knowledge documents.",
+                    "type": "string",
+                    "minLength": 1,
+                    "examples": [
+                        "951999a"
+                    ]
+                },
+                "pattern": {
+                    "description": "An array of glob patterns of the knowledge documents in the Git repository.",
+                    "type": "array",
+                    "minItems": 1,
+                    "uniqueItems": true,
+                    "items": {
+                        "type": "string",
+                        "minLength": 1,
+                        "examples": [
+                            "*.md"
+                        ]
                     }
                 }
             }

--- a/.github/scripts/check-yaml.sh
+++ b/.github/scripts/check-yaml.sh
@@ -29,8 +29,8 @@ for file in ${CHANGED_FILES}; do
       compositional_skills/*/qna.yaml)
         eval "$(check-jsonschema --schemafile $SCHEMAS/compositional_skills.json -o JSON $file | jq -r '.errors[] | (.path | ltrimstr("$") | select(. != "") // ".") as $path | "\($path)|line" as $yqline | @sh "$(yq \($yqline) \(.filename))" as $yqcmd | @sh "\(.message[-200:])" as $message | "error \"\(.filename):\($yqcmd):1\" \"\($path)\" \($message)"')"
         ;;
-      knowledge/*)
-        error "$file:1:1" "." "We do not accept knowledge PRs at this time"
+      knowledge/*/qna.yaml)
+        eval "$(check-jsonschema --schemafile $SCHEMAS/knowledge.json -o JSON $file | jq -r '.errors[] | (.path | ltrimstr("$") | select(. != "") // ".") as $path | "\($path)|line" as $yqline | @sh "$(yq \($yqline) \(.filename))" as $yqcmd | @sh "\(.message[-200:])" as $message | "error \"\(.filename):\($yqcmd):1\" \"\($path)\" \($message)"')"
         ;;
       *)
         error "$file:1:1" "." "Taxonomy file must be named 'qna.yaml', not '$(basename $file)'"


### PR DESCRIPTION
We update the knowledge schema based upon
https://github.com/instruct-lab/taxonomy/pull/641.

We also enable knowledge PR submissions by updating check-yaml.sh and validating against the knowledge schema.

Closes #635 

