### PR TITLE
knowledge: Pivot to Git submodules

### DIFF
--- a/.github/schemas/v1/knowledge.json
+++ b/.github/schemas/v1/knowledge.json
@@ -8,7 +8,7 @@
         "domain",
         "task_description",
         "seed_examples",
-        "document"
+        "documents"
     ],
     "unevaluatedProperties": false,
     "properties": {
@@ -53,45 +53,17 @@
                 }
             }
         },
-        "document": {
-            "description": "The knowledge documents.",
-            "type": "object",
-            "required": [
-                "repo",
-                "commit",
-                "pattern"
-            ],
-            "unevaluatedProperties": false,
-            "properties": {
-                "repo": {
-                    "description": "The URL to a Git repository holding the knowledge documents.",
-                    "type": "string",
-                    "minLength": 1,
-                    "examples": [
-                        "https://github.com/instruct-lab/cli"
-                    ]
-                },
-                "commit": {
-                    "description": "The commit in the Git repository containing the knowledge documents.",
-                    "type": "string",
-                    "minLength": 1,
-                    "examples": [
-                        "951999a"
-                    ]
-                },
-                "pattern": {
-                    "description": "An array of glob patterns of the knowledge documents in the Git repository.",
-                    "type": "array",
-                    "minItems": 1,
-                    "uniqueItems": true,
-                    "items": {
-                        "type": "string",
-                        "minLength": 1,
-                        "examples": [
-                            "*.md"
-                        ]
-                    }
-                }
+        "documents": {
+            "description": "An array of glob patterns of the knowledge documents relative to the knowledge skill file.",
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true,
+            "items": {
+                "type": "string",
+                "minLength": 1,
+                "examples": [
+                    "documents/*.md"
+                ]
             }
         }
     }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "knowledge/textbook/history/ibm_history/documents"]
+	path = knowledge/textbook/history/ibm_history/documents
+	url = https://github.com/abhi1092/ibm-history-documents.git

--- a/knowledge/technical_manual/ibm_redbooks/qna.yaml
+++ b/knowledge/technical_manual/ibm_redbooks/qna.yaml
@@ -30,10 +30,7 @@ seed_examples:
     D. It is used for visualizing and navigating the EHS location hierarchy in a graphical
     interface.'
 task_description: ''
-document:
-  repo: <document-repository-url-goes-here>
-  commit: <commit-hash-to-use>
-  pattern:
-    - <file-search-patter 1>
-    - <file-search-patter 2>
-    - <file-search-patter 3>
+documents:
+- <file-search-pattern 1>
+- <file-search-pattern 2>
+- <file-search-pattern 3>

--- a/knowledge/textbook/history/ibm_history/qna.yaml
+++ b/knowledge/textbook/history/ibm_history/qna.yaml
@@ -50,9 +50,6 @@ seed_examples:
     question: Describe the challenges the Computing-Tabulating-Recording Company
       faced shortly after its formation and how these were overcome.
 task_description: ""
-document:
-  repo: https://github.com/abhi1092/ibm-history-documents
-  commit: 1dc85d0fc19e21ad8adbf5f98bd8aa1e31257d0a
-  pattern:
-    - ibm*.md
-    - origins_of_ibm*.md
+documents:
+- documents/ibm*.md
+- documents/origins_of_ibm*.md


### PR DESCRIPTION
[Submodule docs][1] and [Pro Git chapter][2].  This way we can use that off-the-shelf tooling for linking dependent Git repositories, instead of building something similar on our own.  I'm dropping #641's `repo` and `commit` now that that portion has been offloaded to submodules.

There's no upstream-Git analog to pattern, although recent versions do have [an experimental `sparse-checkout`][3].  But the files will be pulled down by the clone either way, so it doesn't seem like a big deal to land them all on the filesystem, and then use the regular expressions to iterate over the files you actually want to feed the model while training.

```yaml
document:
  pattern:
  - regular expression 1
  - regular expression 2
  - ...
```

seemed a bit chatty, now that we're only holding an array of regular expressions, so I'm flattening to a single:

```yaml
documents:
- regular expression 1
- regular expression 2
- ...
```

[1]: https://git-scm.com/docs/gitsubmodules
[2]: https://git-scm.com/book/en/v2/Git-Tools-Submodules
[3]: https://git-scm.com/docs/git-sparse-checkout
