### PR TITLE
Adds link to community maintainers repo

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,1 @@
+For a complete list of InstructLab project maintainers, see [Maintainers](https://github.com/instruct-lab/community/blob/main/MAINTAINERS.md).


### PR DESCRIPTION
This PR adds a link for the Maintainers.md file that links to the Community Maintainers.md file. 

Addresses https://github.com/orgs/instruct-lab/projects/1/views/1?pane=issue&itemId=59049356 