### PR TITLE
Adds link to security advisory page under the community repo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,3 +1,5 @@
 # Security Policy
 
 Please take a look at the default project [Security Policy](https://github.com/instruct-lab/community/blob/main/SECURITY.md).
+
+To report a security issue, see [Security Advisories](https://github.com/instruct-lab/community/security/advisories).


### PR DESCRIPTION
This PR addresses https://github.com/instruct-lab/community/issues/101 by adding a link security advisory page under the Community repository. 