### PR TITLE
Add a skill to check if a passage is too ambiguous to support a claim

### DIFF
--- a/compositional_skills/linguistics/ambiguity_detection/qna.yaml
+++ b/compositional_skills/linguistics/ambiguity_detection/qna.yaml
@@ -1,0 +1,89 @@
+created_by: ae2015
+task_description: >
+    Given a passage and a claim, determine if the passage is sufficient
+    to conclude the claim. Pay attention to ambiguities in the passage,
+    such as unresolved pronouns, missing values, and phrases with many
+    possible interpretations.
+seed_examples:
+- context: >
+    Passage:
+
+    This model of XYZ is compatible with Product ABC and Product DEF.
+
+    Claim:
+
+    Model M1 of accessory XYZ only works with Product ABC and Product DEF.
+  question: >
+    Is Passage sufficient to conclude Claim?
+  answer: >
+    No, the passage is not sufficient to conclude the claim. The claim is
+    about model M1 of accessory XYZ, but the passage does not mention
+    model M1 of accessory XYZ. Phrase "This model of XYZ" in the passage
+    can refer to a different model of XYZ, not necessarily to model M1.
+
+- context: >
+    Passage:
+
+    You can avoid the monthly service fee for ABC Checking Account if you
+    maintain at least $500 minimum daily balance.
+
+    Claim:
+
+    ABC Checking Account has a monthly service fee of $10.
+  question: >
+    Is Passage sufficient to conclude Claim?
+  answer: >
+    No, the passage is not sufficient to conclude the claim. The claim
+    states that ABC Checking Account's monthly service fee is $10, but
+    the passage does not mention the fee's amount in any way.
+
+- context: >
+    Passage:
+
+    What I saw today was the most wonderful and magnificent thing I have ever witnessed.
+
+    Claim:
+
+    Today's solar eclipse has made a strong impression on me.
+  question: >
+    Is Passage sufficient to conclude Claim?
+  answer: >
+    No, the passage is not sufficient to conclude the claim. The claim
+    is about a solar eclipse, but the passage makes no mention of a
+    solar eclipse. Phrases "What I saw today" and "the most wonderful
+    and magnificent thing" in the passage could refer to many different
+    things or phenomena, for example to a rocket launch or a blooming
+    meadow; we cannot conclude that they must refer to a solar eclipse.
+
+- context: >
+    Passage:
+
+    Many tech stocks have been doing really well last week, with XYZ Technologies
+    growing at breakneck pace.
+
+    Claim:
+
+    The shares of XYZ Technologies grew by more than 300% by the end of last week.
+  question: >
+    Is Passage sufficient to conclude Claim?
+  answer: >
+    No, the passage is not sufficient to conclude the claim. The claim states that
+    the shares of XYZ Technologies grew by more than 300%, but the passage makes
+    no mention of a growth rate above 300%. Phrase "growing at breakneck pace" in
+    the passage is subjective and does not represent any specific number or range.
+
+- context: >
+    Passage:
+
+    One of its key features is the ability to easily work with multiple
+    projects at the same time.
+
+    Claim:
+
+    Maven is able to easily work with multiple projects at the same time.
+  question: >
+    Is Passage sufficient to conclude Claim?
+  answer: >
+    No, the passage is not sufficient to conclude the claim. The claim is
+    about Maven, but the passage does not mention Maven. Pronoun "its" in
+    the passage can refer to anything, not necessarily to Maven.


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

Given a text passage and a claim, determine if the passage is sufficient to conclude the claim. Here we are looking at passages that may be too ambiguous to support the claim, because they

- contain unresolved pronouns or pronoun phrases
- miss specific entity names or numerical values
- use phrases with too many possible interpretations
- use subjective language (rather than objective)

This skill is a prerequisite for the ability to generate grounded responses that are free from exaggerated or careless claims.

**Input given at the prompt**

In one example, we provide the following context to Merlinite 7b:
```
Passage:

What I saw today was the most wonderful and magnificent thing I have ever witnessed.

Claim:

Today's solar eclipse has made a strong impression on me.
```
Then we ask Merlinite 7b the following question:
```
Is Passage sufficient to conclude Claim?
```
Merlinite 7b wrongly answers "yes" and explains as follows:

**Response from the original model**

```
Yes, the passage is sufficient to conclude the claim. The speaker uses the words "wonderful" and
"magnificent" to describe what they saw today, which aligns with the experience of viewing a
solar eclipse. This strong impression suggests that the passage refers to the solar eclipse, making
the claim plausible.
```
So, for the current model, a suggested plausible interpretation is all it takes to conclude the claim. In other examples, the model tacitly substituted a pronoun in the passage with a specific entity name or let a numerical value stand without any grounding.

**Response from the fine-tuned model**

(did not have an opportunity to fine tune the model)

**Contribution checklist**

- [x] The contribution was tested with `lab generate`
- [x] No errors or warnings were produced by `lab generate`
- [x] All [commits are signed off](https://github.com/instruct-lab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
