### PR TITLE
Handle multiple yaml files in lint action

### DIFF
--- a/.github/scripts/check-yaml.py
+++ b/.github/scripts/check-yaml.py
@@ -236,7 +236,11 @@ def cli() -> int:
         action="append",
         metavar="TAXONOMY_FOLDER",
         dest="taxonomy_folders",
-        help="A taxonomy folder. This argument can be specified multiple times.",
+        help="""
+            A taxonomy folder. This argument can be specified multiple times.
+            Alternately, the TAXONOMY_FOLDERS environment variable can be used
+            to specify a space-separated list of folders.
+            """,
         default=os.environ.get(
             "TAXONOMY_FOLDERS", "compositional_skills knowledge"
         ).split(),
@@ -244,7 +248,11 @@ def cli() -> int:
     parser.add_argument(
         "-s",
         "--schema-base",
-        help="The base directory of the Taxonomy schema files.",
+        help="""
+            The base directory of the Taxonomy schema files.
+            Alternately, the SCHEMA_BASE environment variable can be used
+            to specify the base directory.
+            """,
         default=os.environ.get("SCHEMA_BASE", _find_schema_base()),
         type=Path,
     )
@@ -252,7 +260,11 @@ def cli() -> int:
         "-l",
         "--lint-config",
         dest="yamllint_config",
-        help="The yamllint configuration.",
+        help="""
+            The yamllint configuration data.
+            Alternately, the YAMLLINT_CONFIG environment variable can be used
+            to specify the configuration data.
+            """,
         default=os.environ.get(
             "YAMLLINT_CONFIG", "{extends: relaxed, rules: {line-length: {max: 120}}}"
         ),

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Check YAML file contents"
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          .github/scripts/check-yaml.py "${{ steps.changed-files.outputs.all_changed_files }}"
+          .github/scripts/check-yaml.py ${{ steps.changed-files.outputs.all_changed_files }}
         env:
           SCHEMA_BASE: .github/schemas
           YAMLLINT_CONFIG: "{extends: relaxed, rules: {line-length: {max: 120}}}"


### PR DESCRIPTION
The lint action incorrectly quoted the list of yaml files which resulted in them
being a single argument to the check-yaml script instead of multiple
arguments.

The help text for the check-yaml script options is improved to document the env vars which can be used as an alternate way to specify options.