### PR TITLE
Add a skill for detecting contradiction between two short passages

### DIFF
--- a/compositional_skills/linguistics/check_contradiction/attribution.txt
+++ b/compositional_skills/linguistics/check_contradiction/attribution.txt
@@ -1,0 +1,111 @@
+created_by: ae2015
+task_description: >
+    Given two short text passages, determine if they contradict each other.
+seed_examples:
+- context: >
+    Passage 1:
+
+    All employees in Plan ABC are eligible for Service XYZ; however, employees
+    in HMOs, or who have opted out, are not eligible to use Service XYZ.
+
+    Passage 2:
+
+    All employees in Plan ABC are eligible for Service XYZ. This includes employees
+    in HMOs, but excludes those who have opted out. 
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. In Passage 1, employees in HMOs are
+    not eligible to use Service XYZ, while in Passage 2, employees in HMOs are
+    eligible to use Service XYZ, which is a contradiction.
+  attribution:
+  - source: self-authored
+    license: Apache-2.0
+
+- context: >
+    Passage 1:
+
+    The rotating screen of Product XYZ can set its orientation to Portrait or
+    Landscape modes.
+
+    Passage 2:
+
+    Product XYZ is similar to ABC but, instead of having a rotating screen,
+    XYZ can set its orientation to Portrait or Landscape modes.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. In Passage 1, Product XYZ has a
+    rotating screen, while in Passage 2, the word "instead" implies that
+    Product XYZ does not have a rotating screen, which is a contradiction.
+  attribution:
+  - source: self-authored
+    license: Apache-2.0
+
+- context: >
+    Passage 1:
+
+    Model ABC is available either with 128GB of storage and 8GB of RAM,
+    or with 256GB of storage and 12GB of RAM.
+    Model XYZ is available either with 256GB of storage and 8GB of RAM,
+    or with 512GB of storage and 12GB of RAM.
+
+    Passage 2:
+
+    Models ABC and XYZ are available with 128GB, 256GB, or 512GB of storage.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. Passage 1 implies that Model XYZ
+    is not available with 128GB of storage, while in Passage 2, Model XYZ
+    is available with 128GB of storage, which is a contradiction.
+  attribution:
+  - source: self-authored
+    license: Apache-2.0
+
+- context: >
+    Passage 1:
+
+    Product XYZ offers some features that Product ABC does not. For example,
+    XYZ has a touchscreen, while ABC has a keyboard instead.
+
+    Passage 2:
+
+    Product XYZ offers more features to its users than Product ABC. For example,
+    only XYZ uses a touchscreen.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. In Passage 1, Product ABC has a feature
+    that Product XYZ does not have, namely a keyboard; the word "instead"
+    implies that Product XYZ does not have a keyboard. But in Passage 2, phrase
+    "offers more features" implies that all features of Product ABC are also
+    features of Product XYZ, hence Product XYZ must feature a keyboard too,
+    which is a contradiction with Passage 1.
+  attribution:
+  - source: self-authored
+    license: Apache-2.0
+
+- context: >
+    Passage 1:
+
+    The product models compatible with Accessory ABC are: MX, MY, and MZ.
+    The product models compatible with Accessory DEF are: MZ and MT.
+
+    Passage 2:
+
+    Our more advanced accessory ABC is compatible with more product models
+    than our older accessory DEF.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. It follows from Passage 1 that
+    Accessory ABC is not compatible with product model MT and Accessory DEF is
+    compatible with MT. However, phrase "compatible with more product models"
+    in Passage 2 implies that Accessory ABC is compatible with all product models
+    compatible with DEF plus some more models. Since DEF is compatible with MT,
+    Passage 2 implies that ABC is also compatible with MT, which is a
+    contradiction with Passage 1.
+  attribution:
+  - source: self-authored
+    license: Apache-2.0

--- a/compositional_skills/linguistics/check_contradiction/qna.yaml
+++ b/compositional_skills/linguistics/check_contradiction/qna.yaml
@@ -1,0 +1,96 @@
+created_by: ae2015
+task_description: >
+    Given two short text passages, determine if they contradict each other.
+seed_examples:
+- context: >
+    Passage 1:
+
+    All employees in Plan ABC are eligible for Service XYZ; however, employees
+    in HMOs, or who have opted out, are not eligible to use Service XYZ.
+
+    Passage 2:
+
+    All employees in Plan ABC are eligible for Service XYZ. This includes employees
+    in HMOs, but excludes those who have opted out.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. In Passage 1, employees in HMOs are
+    not eligible to use Service XYZ, while in Passage 2, employees in HMOs are
+    eligible to use Service XYZ, which is a contradiction.
+
+- context: >
+    Passage 1:
+
+    The rotating screen of Product XYZ can set its orientation to Portrait or
+    Landscape modes.
+
+    Passage 2:
+
+    Product XYZ is similar to ABC but, instead of having a rotating screen,
+    XYZ can set its orientation to Portrait or Landscape modes.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. In Passage 1, Product XYZ has a
+    rotating screen, while in Passage 2, the word "instead" implies that
+    Product XYZ does not have a rotating screen, which is a contradiction.
+
+- context: >
+    Passage 1:
+
+    Model ABC is available either with 128GB of storage and 8GB of RAM,
+    or with 256GB of storage and 12GB of RAM.
+    Model XYZ is available either with 256GB of storage and 8GB of RAM,
+    or with 512GB of storage and 12GB of RAM.
+
+    Passage 2:
+
+    Models ABC and XYZ are available with 128GB, 256GB, or 512GB of storage.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. Passage 1 implies that Model XYZ
+    is not available with 128GB of storage, while in Passage 2, Model XYZ
+    is available with 128GB of storage, which is a contradiction.
+
+- context: >
+    Passage 1:
+
+    Product XYZ offers some features that Product ABC does not. For example,
+    XYZ has a touchscreen, while ABC has a keyboard instead.
+
+    Passage 2:
+
+    Product XYZ offers more features to its users than Product ABC. For example,
+    only XYZ uses a touchscreen.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. In Passage 1, Product ABC has a feature
+    that Product XYZ does not have, namely a keyboard; the word "instead"
+    implies that Product XYZ does not have a keyboard. But in Passage 2, phrase
+    "offers more features" implies that all features of Product ABC are also
+    features of Product XYZ, hence Product XYZ must feature a keyboard too,
+    which is a contradiction with Passage 1.
+
+- context: >
+    Passage 1:
+
+    The product models compatible with Accessory ABC are: MX, MY, and MZ.
+    The product models compatible with Accessory DEF are: MZ and MT.
+
+    Passage 2:
+
+    Our more advanced accessory ABC is compatible with more product models
+    than our older accessory DEF.
+  question: >
+    Does Passage 1 contradict Passage 2?
+  answer: >
+    Yes, Passage 1 contradicts Passage 2. It follows from Passage 1 that
+    Accessory ABC is not compatible with product model MT and Accessory DEF is
+    compatible with MT. However, phrase "compatible with more product models"
+    in Passage 2 implies that Accessory ABC is compatible with all product models
+    compatible with DEF plus some more models. Since DEF is compatible with MT,
+    Passage 2 implies that ABC is also compatible with MT, which is a
+    contradiction with Passage 1.


### PR DESCRIPTION
This is a re-submission of [**PR 663**](https://github.com/instructlab/taxonomy/pull/663).

**Describe the contribution to the taxonomy**

Given two short text passages, determine if they directly contradict each other.

- Focus on obvious single-step contradictions
- Better understand restrictive words such as "instead", "includes", "more features" etc.
- Check all claims made by the passage, not just the main claim
- Address errors often seen in grounded response generation

**Input given at the prompt**

Here is an example of two short text passages that contradict each other:
```
Passage 1:

All employees in Plan ABC are eligible for Service XYZ; however, employees
in HMOs, or who have opted out, are not eligible to use Service XYZ.

Passage 2:

All employees in Plan ABC are eligible for Service XYZ. This includes employees
in HMOs, but excludes those who have opted out.
```
They contradict because, in Passage 1, employees in HMOs are not eligible to use Service XYZ, while in Passage 2, employees in HMOs are eligible to use Service XYZ. However, when Merlinite 7b is asked question
```
Does Passage 1 contradict Passage 2?
```
it does not detect this contradiction. Let us take a look at two different wrong responses made by Merlinite 7b:

**Response from the original model**

Wrong answer 1:
```
No, the passages do not contradict each other. Both passages state that all employees in Plan ABC are
eligible for Service XYZ, with the exception of those who have opted out. However, Passage 1 clarifies
that this does not include employees who are part of HMOs, while Passage 2 explicitly mentions that
HMO employees are included. Therefore, both passages convey the same information, just with slightly
different wording and emphasis.
```
Wrong answer 2:
```
The passages do not contradict each other. Passage 1 states that all employees in Plan ABC are eligible
for Service XYZ, with the exception of those in HMOs or who have opted out. Passage 2 also states that
all employees in Plan ABC are eligible for Service XYZ, but clarifies that this includes employees in HMOs
and excludes those who have opted out. The passages share the same information, but passage 2
provides additional clarity on the inclusion of HMO employees. 
```
We can see that the contradiction was not detected for two reasons:
- Not grasping the full meaning of the word "includes" - that it actually implies being eligible for Service XYZ;
- Disregarding claims made about employees in HMOs as "slightly different wording" of the main claim.

Better understanding of restrictive words and better attention to all claims the passage is making would likely improve both contradiction detection and grounded response generation.

**Response from the fine-tuned model**

(did not have an opportunity to fine tune the model)

**Contribution checklist**

- [x] The contribution was tested with `ilab generate`
- [x] No errors or warnings were produced by `ilab generate`
- [x] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [x] An `attribution.txt` file in the same folder as the `qna.yaml` file.
