### PR TITLE
ci: Change labeler configuration to remove syncing

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -15,4 +15,4 @@ jobs:
     - uses: actions/labeler@v5
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        sync-labels: true
+        sync-labels: false


### PR DESCRIPTION
The syncing was re-adding existing labels on each push to a PR which caused issues for the bot.

