### PR TITLE
chore: Add avoid topics to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -53,3 +53,5 @@ Replace "..." with what you receive with the finetuned model. -->
 - [ ] The `qna.yaml` file contains at least 5 `seed_examples`
 - [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
 - [ ] An `attribution.txt` file in the same folder as the `qna.yaml` file.
+- [ ] Content does not include PII or otherwise sensitive or confidential information
+- [ ] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instruct-lab/community/blob/main/docs/README.md#avoid-these-topics) guidelines


### PR DESCRIPTION
Add a checkbox to make sure taxonomy contributions follow (don't fall into) the avoid-topics list

FYI @jjasghar @lhawthorn

---


**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] The contribution was tested with `ilab generate`
- [ ] No errors or warnings were produced by `ilab generate`
- [ ] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file contains at least 5 `seed_examples`
- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [ ] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [ ] Content does not include PII or otherwise sensitive or confidential information
- [ ] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instruct-lab/community/blob/main/docs/README.md#avoid-these-topics) guidelines

