### PR TITLE
Fixed a small error with the data

### DIFF
--- a/compositional_skills/extraction/annual_report/plain_text/qna.yaml
+++ b/compositional_skills/extraction/annual_report/plain_text/qna.yaml
@@ -80,9 +80,7 @@ seed_examples:
     industries, clients, and business mix?
 
     '
-- answer: '$7,174,000,000, $8,326,000,000
-
-    '
+- answer: 'The diluted operating (non-GAAP) earnings per share from 2021 were $7.93, and from 2022 they were $9.13. '
   context: "## 8 Management Discussion\n\n## MANAGEMENT DISCUSSION SNAPSHOT\n\n($\
     \ and shares in millions except per share amounts)\n\n| For year ended December\
     \ 31:\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_| 2022 *\_\_\_\_| 2021\_\_\_\_\_\


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

I noticed a small error in the example answer to a question

**Input given at the prompt**

I used the sample from the qna file

**Response from the original model**

```
The diluted operating (non-GAAP) earnings per share from 2021 were $7.93, and from 2022 they were $9.13. 
```

TBH, this is a good answer. I've substituted this into the sample.

**Response from the fine-tuned model**

I have not been able to generate this.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] The contribution was tested with `ilab generate`
- [ ] No errors or warnings were produced by `ilab generate`
- [ ] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file contains at least 5 `seed_examples`
- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [ ] An `attribution.txt` file in the same folder as the `qna.yaml` file.
- [ ] Content does not include PII or otherwise sensitive or confidential information
- [ ] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instruct-lab/community/blob/main/docs/README.md#avoid-these-topics) guidelines
