### PR TITLE
ci: add GitHub Action linter

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Lint GitHub Actions workflows
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - '.github/**'
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - '.github/**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Download actionlint
+        id: get_actionlint
+        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash) 1.6.27
+      - name: Check workflow files
+        run: PATH=".:$PATH" actionlint -color

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -6,12 +6,12 @@ on:
     branches:
       - "main"
     paths:
-      - '.github/**'
+      - '.github/workflows/*.ya?ml'
   pull_request:
     branches:
       - "main"
     paths:
-      - '.github/**'
+      - '.github/workflows/*.ya?ml'
 
 defaults:
   run:


### PR DESCRIPTION
This is a meta-linter of sorts that lints GitHub Actions themselves

Should be useful when we introduce more CI to this repository
