### PR TITLE
schema: Define a relaxed schema as v1 and move current schema to v2

### DIFF
--- a/.github/scripts/check-yaml.py
+++ b/.github/scripts/check-yaml.py
@@ -32,12 +32,22 @@ class CheckYaml:
         schema_base: Path,
         taxonomy_folders: List[str],
         yamllint_config: YamlLintConfig,
+        schema_version: Optional[int] = None,
         message_format: Optional[str] = None,
     ) -> None:
         self.yaml_files = yaml_files
         self.schema_base = schema_base
         self.taxonomy_folders = taxonomy_folders
         self.yamllint_config = yamllint_config
+        if schema_version is None:
+            schema_versions = sorted(
+                int(v.name[1:])
+                for v in self.schema_base.glob("v*")
+                if v.name[1:].isdigit()
+            )
+            if schema_versions:
+                schema_version = schema_versions[-1]
+        self.schema_version = schema_version
         if message_format is None or message_format == "auto":
             message_format = (
                 "github"
@@ -123,6 +133,14 @@ class CheckYaml:
                 )
                 continue
 
+            version = self.schema_version
+            if version is None:
+                self.error(
+                    file=taxonomy_path,
+                    message=f'Schema base "{self.schema_base}" does not contain any schema versions',
+                )
+                continue
+
             try:
                 with open(full_path, "r", encoding="utf-8") as stream:
                     content = stream.read()
@@ -162,13 +180,14 @@ class CheckYaml:
                     )
                     continue
 
-                version = parsed.get("version", 1)
-                if not isinstance(version, int):
-                    # schema validation will complain about the type
-                    try:
-                        version = int(version)
-                    except ValueError:
-                        version = 1  # fallback to version 1
+                if version < 1:  # Use version from YAML document
+                    version = parsed.get("version", 1)
+                    if not isinstance(version, int):
+                        # schema validation will complain about the type
+                        try:
+                            version = int(version)
+                        except ValueError:
+                            version = 1  # fallback to version 1
 
                 schemas_path = self.schema_base.joinpath(f"v{version}")
                 retrieve = partial(self._retrieve, schemas_path)
@@ -221,17 +240,18 @@ class CheckYaml:
                         message=f"Cannot load schema file {e.ref}. {e}",
                     )
 
-                attribution_path = full_path.with_name("attribution.txt")
-                if not os.path.isfile(attribution_path):
-                    self.error(
-                        file=taxonomy_path,
-                        message=f"The {attribution_path.name} file does not exist or is not a file",
-                    )
-                elif os.path.getsize(attribution_path) == 0:
-                    self.error(
-                        file=taxonomy_path.with_name(attribution_path.name),
-                        message="The file must be non-empty",
-                    )
+                if version > 1:
+                    attribution_path = full_path.with_name("attribution.txt")
+                    if not os.path.isfile(attribution_path):
+                        self.error(
+                            file=taxonomy_path,
+                            message=f"The {attribution_path.name} file does not exist or is not a file",
+                        )
+                    elif os.path.getsize(attribution_path) == 0:
+                        self.error(
+                            file=taxonomy_path.with_name(attribution_path.name),
+                            message="The file must be non-empty",
+                        )
 
             except Exception as e:
                 self.exit_code = 1
@@ -271,6 +291,19 @@ def cli() -> int:
         type=Path,
     )
     parser.add_argument(
+        "-v",
+        "--schema-version",
+        help="""
+            The version of the Taxonomy schema.
+            Alternately, the SCHEMA_VERSION environment variable can be used
+            to specify the version.
+            Specifying a version less than 1 will use the schema version specified by each YAML document's "version" key.
+            If not specified, the highest schema version at SCHEMA_BASE is used.
+            """,
+        default=os.environ.get("SCHEMA_VERSION"),
+        type=int,
+    )
+    parser.add_argument(
         "-l",
         "--lint-config",
         dest="yamllint_config",
@@ -305,6 +338,7 @@ def cli() -> int:
         taxonomy_folders=args.taxonomy_folders,
         yamllint_config=args.yamllint_config,
         schema_base=args.schema_base,
+        schema_version=args.schema_version,
         message_format=args.message_format,
     )
     exit_code = check_yaml.check()

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Your skills contribution pull requests must include the following:
 
 Taxonomy skill files must be a valid [YAML](https://yaml.org/) file named `qna.yaml`. Each `qna.yaml` files contains a set of key/value entries with the following keys:
 
+- `version`: The value must be the number 2. **Required**
 - `task_description`: A description of the skill. **Required**
 - `created_by`: The GitHub username of the contributor. **Required**
 - `seed_examples`: A collection of key/value entries. New
@@ -68,12 +69,13 @@ Other keys at any level are currently ignored.
 
 ### Skills: YAML examples
 
-To make the `qna.yaml` files easier and faster for humans to read, it is recommended to specify `task_description` first, followed by `created_by`, and finally `seed_examples`.
+To make the `qna.yaml` files easier and faster for humans to read, it is recommended to specify `version` first, followed by `task_description`, then `created_by`, and finally `seed_examples`.
 In `seed_examples`, it is recommended to specify `context` first (if applicable), followed by `question` and `answer`.
 
 *Example `qna.yaml`*
 
 ```yaml
+version: 2
 task_description: <string>
 created_by: <string>
 seed_examples:
@@ -125,6 +127,7 @@ It is recommended that you **lint**, or verify your YAML using a tool. One linte
 #### Freeform compositional skill: YAML example
 
 ```yaml
+version: 2
 task_description: 'Teach the model how to rhyme.'
 created_by: juliadenham
 seed_examples:
@@ -173,6 +176,7 @@ Remember that [grounded compositional skills](docs/SKILLS_GUIDE.md) require addi
 This example snippet assumes the GitHub username `mairin` and shows some of the question/answer pairs present in the actual file:
 
 ```yaml
+version: 2
 task_description: |
     This skill provides the ability to read a markdown-formatted table.
 created_by: mairin # Use your GitHub username; only one creator supported
@@ -262,8 +266,8 @@ Knowledge in the taxonomy tree consists of a few more elements than skills:
 > of around 2300 words to your question and answer seed example pairs in the `qna.yaml` file.
 
 Each `qna.yaml` file requires a minimum of five question-answer pairs. The `qna.yaml` format must include the following fields:
-ˇ
 
+- `version`: The value must be the number 2.
 - `task_description`: An optional description of the knowledge.
 - `created_by`: Your GitHub username.
 - `domain`: Category of the knowledge.
@@ -278,6 +282,7 @@ Each `qna.yaml` file requires a minimum of five question-answer pairs. The `qna.
 ### Knowledge: YAML examples
 
 ```yaml
+version: 2
 task_description: 'Teach the model the results of the 2024 Oscars'
 created_by: juliadenham
 domain: pop_culture

--- a/knowledge/README.md
+++ b/knowledge/README.md
@@ -4,6 +4,7 @@ Knowledge consists of data and facts and is backed by documents. When you create
 
 Each `qna.yaml` file is required to contain a minimum of five question-answer pairs. The `qna.yaml` format should include the following mandatory fields:
 
+* `version` (The value must be the number 2)
 * `seed_examples` (five or more examples sourced from the provided knowledge documents)
 * `created_by` (your GitHub username)
 * `task_description` (description of your knowledge)


### PR DESCRIPTION
We introduce a relaxed schema as v1 which will accept all existing taxonomy files in the main branch of the taxonomy repo. The current v1 schema is renamed to v2 and will be used for future contributions to the taxonomy repo.

The check_yaml script is updated to allow a schema version to be specified. When the schema-version option is not specified, the script will use the latest schema version from the schema base. If the schema-version is specified as a non-positive integer, then the script will use the version key from the YAML document for the schema version to use.

The script is also changed to only check for attribution.txt when the schema version is higher than 1.

See https://github.com/instructlab/instructlab/issues/989

Depends on https://github.com/instructlab/schema/pull/11

