### PR TITLE
add skill for avoid using prejudicial language

### DIFF
--- a/compositional_skills/writing/freeform/language_skill/attribution.txt
+++ b/compositional_skills/writing/freeform/language_skill/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: Reducing_prejudice
+Link to work: https://en.wikipedia.org/wiki/Prejudice#Reducing_prejudice
+License of the work: CC-BY-SA-4.0
+Creator names: Wikipedia Authors

--- a/compositional_skills/writing/freeform/language_skill/qna.yaml
+++ b/compositional_skills/writing/freeform/language_skill/qna.yaml
@@ -1,0 +1,40 @@
+---
+task_description: Avoid using prejudicial language
+version: 2
+created_by: zhongchanghui
+seed_examples:
+  - context: >
+      This company is looking to hire fresh, young graduates.
+    question: What potential bias exists in this statement? How can it be rephrased?
+    answer: >
+      This company is looking to hire passionate and innovative recent graduates.
+      (Removes the age-related description of "young")
+
+  - context: >
+      We need to retain these seasoned employees, even though they are getting on in years
+      their experience is invaluable.
+    question: Which words in this statement may carry ageist undertones? Please rephrase.
+    answer: >
+      We need to retain these highly experienced employees, as they are a valuable asset to
+      the company. (Avoids the age-related description of "getting on in years")
+
+  - context: >
+      This modern tech startup primarily hires young people because they are better at grasping new technologies.
+    question: How can this be rephrased to avoid stereotyping based on age?
+    answer: >
+      This tech company welcomes passionate and innovative talent, regardless of age.
+      (Removes the positive stereotype about young people)
+
+  - context: >
+      Our company is implementing an innovation strategy and needs to bring in some young blood.
+    question: How can this statement avoid language with potential ageist connotations?
+    answer: >
+      Our company is seeking new talent with fresh perspectives to invigorate the organization.
+      (Avoids using the age-related phrase "young blood")
+
+  - context: >
+      This job requires agility and quick reflexes, so it is more suitable for the younger generation.
+    question: Please rephrase this statement to remove age-related bias.
+    answer: >
+      This job requires good physical fitness and responsiveness, and we welcome applicants with these abilities.
+      (Does not mention age)


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- add skill for avoid using prejudicial language



**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
 context: This company is looking to hire fresh, young graduates. question: What potential bias exists in this statement? How can it be rephrased?
```


**Response from the original model**


<!-- What you received from the original model in response to your input, 
replace "..." -->

```
>>>                                                                                                          [S][default]
>>> context: This company is looking to hire fresh, young graduates. question: What potential bias exists in this stateme
nt? How can it be rephrased?
INFO 2024-04-28 17:55:22,611 _client.py:1026 HTTP Request: POST http://127.0.0.1:8000/v1/chat/completions "HTTP/1.1 200 OK"
╭─────────────────────────────────────────────── merlinite-7b-lab-Q4_K_M ───────────────────────────────────────────────╮
│ In the statement "Based on your description, it seems like the company values fresh perspectives and energy brought   │
│ by young graduates," there's a potential bias towards valuing only young graduates for their fresh perspectives and   │
│ energy. This could unintentionally exclude experienced professionals who might also bring valuable insights to the    │
│ table. To avoid this bias, consider rephrasing it as: "Based on your description, it seems like the company values    │
│ fresh perspectives and energy from both young graduates and experienced professionals."                               │
│                                                                                                                       │
│ By acknowledging the value of experienced professionals, the company can ensure a more inclusive hiring process that  │
│ considers a diverse range of candidates based on their skills, experience, and potential contributions to the team.   │
│ Additionally, this rephrased statement highlights the company's appreciation for fresh perspectives and energy from   │
│ all candidates, creating a more welcoming atmosphere for diverse candidates to apply for open positions.              │
╰────────────────────────────────────────────────────────────────────────────────────────────── elapsed 17.202 seconds ─╯
>>> 
```


**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
>>>                                                                                                                                              [S][default]
>>> context: This company is looking to hire fresh, young graduates. question: What potential bias exists in this statement? How can it be rephrased?
INFO 2024-04-28 22:13:45,754 _client.py:1026 HTTP Request: POST http://127.0.0.1:8000/v1/chat/completions "HTTP/1.1 200 OK"
╭─────────────────────────────────────────── instructlab-merlinite-7b-lab-mlx-q-fused-pt/ggml-model-Q4_K_M.gguf ────────────────────────────────────────────╮
│ The statement "This company is looking to hire fresh, young graduates" could be perceived as favoring candidates who recently graduated from university,  │
│ potentially excluding those with relevant experience who may not meet the "fresh" criteria. To avoid this bias, the statement could be rephrased as "This │
│ company is looking for entry-level candidates with a strong background in [specific field]." (Avoids favoring recent graduates)                           │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 9.971 seconds ─╯
>>> 
```

```
>>>                                                                                                                                              [S][default]
>>> context: This company is looking to hire fresh, young graduates. question: What potential bias exists in this statement? How can it be rephrased?
INFO 2024-04-28 22:33:29,158 _client.py:1026 HTTP Request: POST http://127.0.0.1:8000/v1/chat/completions "HTTP/1.1 200 OK"
╭─────────────────────────────────────────── instructlab-merlinite-7b-lab-mlx-q-fused-pt/ggml-model-Q4_K_M.gguf ────────────────────────────────────────────╮
│ The original statement may unintentionally favor applicants who are young and recently graduated, potentially excluding those with more experience. To    │
│ avoid this bias, the statement can be modified as follows: "We welcome applications from individuals with diverse backgrounds and experiences, including  │
│ recent graduates." (Avoids favoring young graduates)                                                                                                      │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 7.337 seconds ─╯
>>>  
```


**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `ilab generate`
- [x] No errors or warnings were produced by `ilab generate`
- [x] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [ ] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [x] Content does not include PII or otherwise sensitive or confidential information
- [x] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instructlab/community/blob/main/docs/SKILLS_GUIDE.md#avoid-these-topics) guidelines
