### PR TITLE
Link to Taxonomy Tree in readme.md is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Below is an illustrative directory structure to show this layout:
                         attribution.txt
 ```
 
-For an extensive example of this layout see, [taxonomy_tree_layout](https://github.com/instructlab/taxonomy/tree/main/docs/taxonomy_tree_layout.md) in the documentation folder.
+For an extensive example of this layout see, [taxonomy_tree_layout](https://github.com/instructlab/taxonomy/blob/main/docs/taxonomy_diagram.png) in the documentation folder.
 
 ## Contribute knowledge and skills to the taxonomy
 


### PR DESCRIPTION
Fixed broken link to the taxonomy tree in the readme.md