### PR TITLE
Updated per the triager conversation

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           stale-pr-label: 'stale'
           stale-pr-message: >
-            This pull request has been automatically marked as stale because it has not had activity within 90 days.
-            It will be automatically closed if no further activity occurs within 30 days.
+            This pull request has been automatically marked as stale because it has not had activity within 15 days.
+            It will be automatically closed if no further activity occurs within 31 days.
           close-pr-message: >
             This pull request has been automatically closed due to inactivity.
-          days-before-stale: 90
-          days-before-close: 30
+          days-before-stale: 15
+          days-before-close: 31


### PR DESCRIPTION
We got overwhelmed with requests from Summit, this is to give the bot the way to stale out PRs that haven't been touched in 2 weeks.

