### PR TITLE
stale: Update configuration for issue staleness

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -30,11 +30,20 @@ jobs:
       - name: "Stale Action"
         uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e # v9.0.0
         with:
+          stale-issue-label: 'stale'
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had activity within 60 days.
+            It will be automatically closed if no further activity occurs within 31 days.
+          close-issue-message: >
+            This issue has been automatically closed due to inactivity.
+          days-before-issue-stale: 60
+          days-before-issue-close: 31
           stale-pr-label: 'stale'
           stale-pr-message: >
             This pull request has been automatically marked as stale because it has not had activity within 15 days.
             It will be automatically closed if no further activity occurs within 31 days.
           close-pr-message: >
             This pull request has been automatically closed due to inactivity.
-          days-before-stale: 15
-          days-before-close: 31
+          days-before-pr-stale: 15
+          days-before-pr-close: 31
+          exempt-pr-labels: triage-approved


### PR DESCRIPTION
Since the stale bot is configured, we also need to configure for issues. When an issue is marked stale, we want a comment added to alert those following the issue. We also want to configure the days rather than use the default.

Finally, we exempt PRs labeled triage-approved from being marked stale to allow the necessary time for such PRs to go through the backend process.

