### PR TITLE
Interstate 84 (Pennsylvania–Massachusetts)

### DIFF
--- a/knowledge/geography/highways/interstate_84/attribution.txt
+++ b/knowledge/geography/highways/interstate_84/attribution.txt
@@ -1,0 +1,5 @@
+Title of work: Interstate 84 (Pennsylvania–Massachusetts)
+Link to work: https://en.wikipedia.org/wiki/Interstate_84_(Pennsylvania–Massachusetts)
+Revision: https://en.wikipedia.org/w/index.php?title=Interstate_84_(Pennsylvania–Massachusetts)&oldid=1212514573
+License of the work: CC-BY-SA-4.0
+Creator names: Wikipedia Authors

--- a/knowledge/geography/highways/interstate_84/qna.yaml
+++ b/knowledge/geography/highways/interstate_84/qna.yaml
@@ -1,0 +1,54 @@
+created_by: makelinux
+domain: geography
+seed_examples:
+  - question:
+      What are some notable geographical features and landmarks
+      along Interstate 84's route?
+    answer:
+      Interstate 84 passes through the Pocono Mountains in Pennsylvania and
+      crosses the Delaware and Neversink rivers in New York. It also intersects
+      with major roads like the New York State Thruway (I-87) and the Taconic
+      State Parkway in New York. In Connecticut, it crosses the Housatonic River
+      on the Rochambeau Bridge and the Connecticut River on the Bulkeley Bridge.
+  - question:
+      How does Interstate 84 contribute to transportation between major
+      cities in the Northeast?
+    answer:
+      Interstate 84 serves as a crucial route between New York City and
+      Boston, passing through major cities like Hartford, Connecticut. It
+      provides a high-speed connection for both passenger and commercial
+      traffic, facilitating travel and commerce between these metropolitan
+      areas.
+  - question:
+      What historical and developmental challenges did Interstate 84 face in
+      its construction and expansion?
+    answer:
+      Interstate 84 faced challenges in its original proposed route,
+      particularly in Rhode Island due to environmental concerns about its
+      impact on the Scituate Reservoir. Additionally, widening projects in
+      Waterbury, Connecticut, experienced cost overruns, delays, and
+      construction defects, leading to investigations and legal actions.
+  - question:
+      How did Interstate 86 relate to Interstate 84 in Connecticut and
+      Massachusetts?
+    answer:
+      Interstate 86 was a designation used for a section of Interstate 84
+      between East Hartford, Connecticut, and Sturbridge, Massachusetts. It was
+      signed in the late 1970s and early 1980s but was later redesignated as
+      I-84 in 1984. The renumbering also affected adjacent roads like I-384 and
+      US 6.
+  - question:
+      Are there any tolls associated with Interstate 84?
+    answer:
+      Generally, Interstate 84 does not have tolls, except for the
+      Newburgh–Beacon Bridge crossing the Hudson River in New York, which
+      carries an eastbound-only toll for passenger vehicles. Additionally, there
+      were tolls on I-84 in New York from 1992 to 2006, managed by the New York
+      State Thruway Authority, before being transferred back to NYSDOT.
+task_description:
+  Interstate 84 (Pennsylvania–Massachusetts)
+document:
+  repo: https://github.com/juliadenham/Summit_knowledge
+  commit: HEAD
+  patterns:
+    - interstate_84.md


### PR DESCRIPTION
Closes #822


**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `ilab generate`
- [x] No errors or warnings were produced by `ilab generate`
- [x] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [x] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [x] Content does not include PII or otherwise sensitive or confidential information
- [x] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instructlab/taxonomy/blob/main/docs/SKILLS_GUIDE.md#avoid-these-topics) guidelines


### 1: What are some notable geographical features and landmarks along Interstate 84's route?
Pre-trainted:
_Interstate 84 (I-84) is a major interstate highway in the United States, stretching from the northeastern part of the country to the northwestern region. Along its route, there are several notable geographical features and landmarks that are worth mentioning:

1. **Hoosac Range:** I-84 passes throug..._

Provided:
Interstate 84 passes through the Pocono Mountains in Pennsylvania and crosses the Delaware and Neversink rivers in New York. It also intersects with major roads like the New York State Thruway (I-87) and the Taconic State Parkway in New York. In Connecticut, it crosses the Housatonic River on the Rochambeau Bridge and the Connecticut River on the Bulkeley Bridge.

Fine-tuned:
Some notable geographical features and landmarks along Interstate 84's route include the Housatonic River in Connecticut, which is the only major river that the interstate crosses, and the Scituate Reservoir in Rhode Island, which is the longest tunnel on the interstate, at 1,472 feet. Additionally, the interstate passes through several historic and culturally significant areas, such as the Mark Twain House in Connecticut, which was the home of the renowned author, and the University of Rhode Island, which is the state's flagship public university. The interstate also passes through several major cities, including Danbury, Waterbury, and Hartford in Connecticut, and Providence in Rhode Island, which is the capital and largest city in the state. Overall, Interstate 84 provides access to a variety of geographical features, landmarks, and cultural sites along its route. 

### 2: How does Interstate 84 contribute to transportation between major cities in the Northeast?
Pre-trainted:
_Interstate 84 is a crucial part of the interstate highway system, particularly in the Northeast region of the United States. It connects several major cities, facilitating transportation and commerce between them. Some of the significant cities connected by Interstate 84 include:

1. **Bangor, Maine..._

Provided:
Interstate 84 serves as a crucial route between New York City and Boston, passing through major cities like Hartford, Connecticut. It provides a high-speed connection for both passenger and commercial traffic, facilitating travel and commerce between these metropolitan areas.

Fine-tuned:
Interstate 84 plays a significant role in connecting major cities in the Northeast, including Providence, Hartford, Springfield, and Waterbury, by providing a direct route between these cities and their respective metropolitan areas. This connection facilitates the movement of people, goods, and services between these regions, promoting economic growth and development. Additionally, I-84 connects to other major interstate highways, such as I-90, I-91, and I-81, allowing for seamless transportation to other parts of the country. The construction of I-84 has also led to the development of various industries and businesses along its route, further strengthening the economic ties between the cities it serves. Overall, I-84 contributes to the regional connectivity and economic development of the Northeast by providing a critical transportation infrastructure for the movement of people, goods, and services. 

### 3: What historical and developmental challenges did Interstate 84 face in its construction and expansion?
Pre-trainted:
_Interstate 84, which connects Maine to North Carolina, has faced several historical and developmental challenges during its construction and expansion. One significant challenge was the 1980 collapse of the Twin Falls Bridge in Idaho, which killed 13 people and injured 22. This tragic event led to i..._

Provided:
Interstate 84 faced challenges in its original proposed route, particularly in Rhode Island due to environmental concerns about its impact on the Scituate Reservoir. Additionally, widening projects in Waterbury, Connecticut, experienced cost overruns, delays, and construction defects, leading to investigations and legal actions.

Fine-tuned:
Interstate 84 faced several historical and developmental challenges during its construction and expansion. These challenges include:

1. Route selection: The original route was planned to go through the center of Waterbury, Connecticut, which was later changed due to environmental and community concerns.
2. Funding: The original construction of the interstate was funded by the Federal-Aid Highway Act of 1956, but the expansion faced funding issues, leading to delays and cost overruns.
3. Environmental concerns: The original route in Waterbury faced significant opposition due to environmental and community concerns, leading to the current route being rerouted.
4. Construction challenges: The interstate's construction faced challenges due to the mountainous terrain in the eastern part of the route, which required significant engineering and construction efforts.
5. Tolls: The interstate originally had tolls, which were later removed due to public opposition and the high cost of maintaining the toll facilities.
6. Expansion: The interstate has been expanded over the years to accommodate increased traffic, but this has also led to challenges in maintaining the infrastructure and addressing the environmental impact of the expansion.

These challenges have significantly impacted the construction 

### 4: How did Interstate 86 relate to Interstate 84 in Connecticut and Massachusetts?
Pre-trainted:
_Interstate 86 and Interstate 84 were connected in Connecticut and Massachusetts, with Interstate 86 being a continuation of Interstate 84. This connection allowed for a seamless transition between the two highways, facilitating efficient travel for motorists. The Interstate 86 designation was used t..._

Provided:
Interstate 86 was a designation used for a section of Interstate 84 between East Hartford, Connecticut, and Sturbridge, Massachusetts. It was signed in the late 1970s and early 1980s but was later redesignated as I-84 in 1984. The renumbering also affected adjacent roads like I-384 and US 6.

Fine-tuned:
Interstate 86 was initially planned to be a continuation of Interstate 84 in Connecticut, connecting to the Massachusetts Turnpike (now Massachusetts Route 2) in Massachusetts. However, due to the completion of the Connecticut River crossing in 1982, the original plans for Interstate 86 were abandoned, and the existing portion of Interstate 84 in Connecticut was extended to the Massachusetts state line, becoming the current Interstate 84 in Massachusetts. The Massachusetts Turnpike, now Massachusetts Route 2, serves as the primary east-west route in the region, connecting Springfield, Massachusetts, to Sturbridge, Massachusetts, and providing a connection to the New York State Thruway via the Massachusetts Turnpike in New York. 

### 5: Are there any tolls associated with Interstate 84?
Pre-trainted:
_Interstate 84 does have tolls in certain areas. Here are some details:

- Interstate 84 in Maine is known as the Turnpike, and it has tolls.
- In New York, there are no tolls on Interstate 84.
- In Connecticut, there are tolls on Interstate 84.
- In Massachusetts, there are no tolls on Interstate 84..._

Provided:
Generally, Interstate 84 does not have tolls, except for the Newburgh–Beacon Bridge crossing the Hudson River in New York, which carries an eastbound-only toll for passenger vehicles. Additionally, there were tolls on I-84 in New York from 1992 to 2006, managed by the New York State Thruway Authority, before being transferred back to NYSDOT.

Fine-tuned:
As of my knowledge up to September 2021, there are no tolls on Interstate 84. However, it's always a good idea to check the latest information from reliable sources, as tolls can change over time. For the most recent information, you can refer to the Connecticut Department of Transportation or the New York State Department of Transportation websites, as they maintain the interstate in their respective jurisdictions. Additionally, you can check the AASHTO Tolling Portal for up-to-date information on toll roads and bridges in the United States. 

