### PR TITLE
Remove pull number check from workflow run

### DIFF
--- a/.github/workflows/coc_violation_analysis.yml
+++ b/.github/workflows/coc_violation_analysis.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   annotator-insights:
     runs-on: ubuntu-latest
-    if: ${{ (github.event.workflow_run.conclusion == 'success') && (github.event.workflow_run.pull_requests[0].number != null) }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     name: Run annotator insights
     steps:
       - name: "Harden Runner"


### PR DESCRIPTION
The workflow was not running after some lint operations on a pull request such as after a force push on an existing PR. So we remove the PR number check to see if the workflow runs when expected.

