### PR TITLE
validation: Confirm yaml file contents are an object

### DIFF
--- a/.github/scripts/check-yaml.py
+++ b/.github/scripts/check-yaml.py
@@ -10,7 +10,7 @@ import sys
 from functools import cache, partial
 from importlib.resources.abc import Traversable
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Mapping, Optional, Union
 
 # Third Party
 import yaml
@@ -154,6 +154,12 @@ class CheckYaml:
                 parsed = yaml.safe_load(content)
                 if not parsed:
                     self.error(file=taxonomy_path, message="The file is empty")
+                    continue
+                if not isinstance(parsed, Mapping):
+                    self.error(
+                        file=taxonomy_path,
+                        message="The file is not valid. The top-level element is not an object with key-value pairs.",
+                    )
                     continue
 
                 version = parsed.get("version", 1)


### PR DESCRIPTION
The top-level element of a yaml document can be an object (key-value pairs) or a list. We now test and provide an error message if the top-level element is not an object.

See https://github.com/instructlab/instructlab/issues/1170

