### PR TITLE
Remove faulty debug output

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,5 @@ jobs:
       - name: "Invoke insight handler"
         if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.repository == 'instructlab/taxonomy') }}
         run: |
-          echo "${{ toJSON(github.event) }}"
           curl -X 'POST' "https://pr-analysis-handler.1fuhf5gskmng.us-east.codeengine.appdomain.cloud/analyze-pr?pr_number=${{ github.event.number }}&owner=${{ github.repository_owner }}&repo=${{ github.event.repository.name }}" -H 'accept: application/json' -H 'Authorization: Bearer ${{ secrets.COC_ANALYSIS_TOKEN }}' -d '' &
           echo "CoC violation analysis triggered"


### PR DESCRIPTION
This way of printing the output does not work properly and appears to have caused a failure in the step.

A better solution, if needed:

    jq '.' "$GITHUB_EVENT_PATH"

