### PR TITLE
workflow: Configure insight analysis to a workflow_run

### DIFF
--- a/.github/workflows/insight.yml
+++ b/.github/workflows/insight.yml
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: CoC insight analysis
+
+on:
+  workflow_run:
+    workflows:
+      - Lint
+    types:
+      - completed
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  insight-analysis:
+    runs-on: ubuntu-latest
+    if: ${{ (github.event.workflow_run.event == 'pull_request') && (github.repository == 'instructlab/taxonomy') && (github.event.workflow_run.conclusion == 'success') }}
+    name: Run insight analysis
+    steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: "Debug info"
+        run: |
+          jq '.' "$GITHUB_EVENT_PATH"
+
+      - name: "Download Pull Request number"
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: pull_request_number
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Get Pull Request number"
+        run: |
+          echo "PULL_REQUEST_NUMBER=$(cat pull_request_number.txt)" >> "$GITHUB_ENV"
+
+      - name: "Invoke insight analysis handler"
+        run: |
+          curl -X "POST" "https://pr-analysis-handler.1fuhf5gskmng.us-east.codeengine.appdomain.cloud/analyze-pr?pr_number=${PULL_REQUEST_NUMBER}&owner=${REPOSITORY_OWNER}&repo=${REPOSITORY_NAME}" -H "accept: application/json" -H "Authorization: Bearer ${ANALYSIS_TOKEN}"
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          ANALYSIS_TOKEN: ${{ secrets.COC_ANALYSIS_TOKEN }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,7 +69,7 @@ jobs:
             knowledge/**/*.yml
 
       - name: "Check changed YAML file contents"
-        if: steps.changed-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' }}
         run: |
           .github/scripts/check-yaml.py ${{ steps.changed-files.outputs.all_changed_files }}
         env:
@@ -79,10 +79,18 @@ jobs:
             compositional_skills
             knowledge
 
-      - name: "Invoke insight handler"
+      - name: "Save Pull Request number"
         if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.repository == 'instructlab/taxonomy') }}
         run: |
-          curl -X 'POST' "https://pr-analysis-handler.1fuhf5gskmng.us-east.codeengine.appdomain.cloud/analyze-pr?pr_number=${{ github.event.number }}&owner=${{ github.repository_owner }}&repo=${{ github.event.repository.name }}" -H 'accept: application/json' -H "Authorization: Bearer $COC_ANALYSIS_TOKEN" -d '' &
-          echo "CoC violation analysis triggered"
+          echo "${PULL_REQUEST_NUMBER}" > pull_request_number.txt
         env:
-            COC_ANALYSIS_TOKEN: ${{ secrets.COC_ANALYSIS_TOKEN }}
+          PULL_REQUEST_NUMBER: ${{ github.event.number }}
+
+      - name: "Upload Pull Request number"
+        if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.repository == 'instructlab/taxonomy') }}
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: pull_request_number
+          path: pull_request_number.txt
+          if-no-files-found: error
+          retention-days: 5


### PR DESCRIPTION
We pass the pull request number as an artifact from the lower privilege pull_request workflow to the higher privilege workflow_run workflow. The higher privilege workflow_run workflow has access to the secret for the curl post operation.

See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/

