### PR TITLE
workflow: Handle when a pull request does not contain qna.yaml

### DIFF
--- a/.github/workflows/insight.yml
+++ b/.github/workflows/insight.yml
@@ -46,6 +46,7 @@ jobs:
           echo "PULL_REQUEST_NUMBER=$(cat pull_request_number.txt)" >> "$GITHUB_ENV"
 
       - name: "Invoke insight analysis handler"
+        if: ${{ fromJSON(env.PULL_REQUEST_NUMBER) != 0 }}
         run: |
           curl -X "POST" "https://pr-analysis-handler.1fuhf5gskmng.us-east.codeengine.appdomain.cloud/analyze-pr?pr_number=${PULL_REQUEST_NUMBER}&owner=${REPOSITORY_OWNER}&repo=${REPOSITORY_NAME}" -H "accept: application/json" -H "Authorization: Bearer ${ANALYSIS_TOKEN}"
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -80,14 +80,14 @@ jobs:
             knowledge
 
       - name: "Save Pull Request number"
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.repository == 'instructlab/taxonomy') }}
+        if: ${{ (github.event_name == 'pull_request') && (github.repository == 'instructlab/taxonomy') }}
         run: |
           echo "${PULL_REQUEST_NUMBER}" > pull_request_number.txt
         env:
-          PULL_REQUEST_NUMBER: ${{ github.event.number }}
+          PULL_REQUEST_NUMBER: ${{ steps.changed-files.outputs.any_changed == 'true' && github.event.number || '0' }}
 
       - name: "Upload Pull Request number"
-        if: ${{ (steps.changed-files.outputs.any_changed == 'true') && (github.event_name == 'pull_request') && (github.repository == 'instructlab/taxonomy') }}
+        if: ${{ (github.event_name == 'pull_request') && (github.repository == 'instructlab/taxonomy') }}
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: pull_request_number


### PR DESCRIPTION
Some pull requests are not about skill or knowledge contributions. We change to always upload an artifact so the insight workflow wont fail because it cannot download the artifact. In the case were the PR does not contain qna.yaml, we pass the pull request number 0 so the insight workflow can avoid invoking the insight analysis.

