### PR TITLE
workflow: Set insight workflow run-name to the display_title

### DIFF
--- a/.github/workflows/insight.yml
+++ b/.github/workflows/insight.yml
@@ -2,6 +2,8 @@
 
 name: CoC insight analysis
 
+run-name: ${{ github.event.workflow_run.display_title || github.workflow }}
+
 on:
   workflow_run:
     workflows:


### PR DESCRIPTION
If there is a display_title from the triggering pull request, we use it. Otherwise we use the insight workflow name. This will help in mapping insight workflow runs to the triggering pull request.
