### PR TITLE
workflow: Add workflow to update CoC report on PR close event

### DIFF
--- a/.github/workflows/update-CoC-report.yml
+++ b/.github/workflows/update-CoC-report.yml
@@ -2,10 +2,11 @@
 
 name: Update CoC report
 
-run-name: 'PR Closed: ${{ github.event.pull_request.number}} ${{ github.event.pull_request.title }}'
+run-name: "${{ github.event.pull_request.title }} (#${{ github.event.pull_request.number}})"
 on:
-  pull_request:
-    types: [ closed ]
+  pull_request_target:
+    types:
+      - closed
 
 env:
   LC_ALL: en_US.UTF-8
@@ -20,6 +21,7 @@ permissions:
 jobs:
   update-coc-insight-handler:
     runs-on: ubuntu-latest
+    if: ${{ github.repository == 'instructlab/taxonomy' }}
     name: Update CoC insights handler for PR Close event
     steps:
       - name: "Harden Runner"

--- a/.github/workflows/update-CoC-report.yml
+++ b/.github/workflows/update-CoC-report.yml
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+
+name: Update CoC report
+
+run-name: 'PR Closed: ${{ github.event.pull_request.number}} ${{ github.event.pull_request.title }}'
+on:
+  pull_request:
+    types: [ closed ]
+
+env:
+  LC_ALL: en_US.UTF-8
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  update-coc-insight-handler:
+    runs-on: ubuntu-latest
+    name: Update CoC insights handler for PR Close event
+    steps:
+      - name: "Harden Runner"
+        uses: step-security/harden-runner@a4aa98b93cab29d9b1101a6143fb8bce00e2eac4 # v2.7.1
+        with:
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: "Debug info"
+        run: |
+          jq '.' "$GITHUB_EVENT_PATH"
+
+      - name: "Update CoC insight analysis handler"
+        run: |
+          curl -X "GET" "https://pr-analysis-handler.1fuhf5gskmng.us-east.codeengine.appdomain.cloud/pr-closed?pr_number=${PULL_REQUEST_NUMBER}&owner=${REPOSITORY_OWNER}&repo=${REPOSITORY_NAME}&merged=${IS_MERGED}" -H "accept: application/json" -H "Authorization: Bearer ${ANALYSIS_TOKEN}"
+        env:
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number}}
+          IS_MERGED: ${{ github.event.pull_request.merged }}
+          ANALYSIS_TOKEN: ${{ secrets.COC_ANALYSIS_TOKEN }}


### PR DESCRIPTION
Added a new workflow to automate the process of updating a Pull Request (PR) record when a PR is closed. The workflow sends an HTTP request to the Code of Conduct (CoC) Handler, ensuring that the PR status is accurately reflected in our records.