### PR TITLE
Skill:List specific number synonyms for one word

### DIFF
--- a/compositional_skills/general/synonyms/attribution.txt
+++ b/compositional_skills/general/synonyms/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: To teach a language model how to get a certain number of synonyms.
+Link to work: -
+License of the work: CC BY-NC-SA 4.0
+Creator names: Yanping Liu

--- a/compositional_skills/general/synonyms/qna.yaml
+++ b/compositional_skills/general/synonyms/qna.yaml
@@ -52,14 +52,14 @@ seed_examples:
   - answer: 'Five antonyms for attend are
 
      absent
-     
+
      neglect
-     
+
      disregard
-     
+
      disown
-     
-     ignore  
+
+     ignore
 
       '
     question: List five antonyms for the word attend and separate with newline.

--- a/compositional_skills/general/synonyms/qna.yaml
+++ b/compositional_skills/general/synonyms/qna.yaml
@@ -1,4 +1,4 @@
-version: 2
+version: 3
 created_by: yanpliu
 seed_examples:
   - answer: 'Synonym for Attend is take part in
@@ -49,17 +49,17 @@ seed_examples:
 
       '
     question: List five synonyms for the word beautiful and separate with newline.
-  - answer: 'Five antonyms for Beautiful are
+  - answer: 'Five antonyms for attend are
 
-      ugly
-
-      unattractive
-
-      disgusting
-
-      bad
-
-      awful
+     absent
+     
+     neglect
+     
+     disregard
+     
+     disown
+     
+     ignore  
 
       '
     question: List five antonyms for the word attend and separate with newline.

--- a/compositional_skills/general/synonyms/qna.yaml
+++ b/compositional_skills/general/synonyms/qna.yaml
@@ -1,0 +1,66 @@
+version: 2
+created_by: yanpliu
+seed_examples:
+  - answer: 'Synonym for Attend is take part in
+
+      '
+    question: List a synonym for the word attend.
+  - answer: 'Two synonyms for Attend are
+
+      take part in
+
+      be present at
+
+      '
+    question: List two synonyms for the word attend and separate with newline.
+  - answer: 'Three synonyms for Attend are
+
+      take part in
+
+      be present at
+
+      be there at
+
+      '
+    question: List three synonyms for the word attend and separate with newline.
+  - answer: 'Four synonyms for Attend are
+
+      take part in
+
+      be present at
+
+      be there at
+
+      make an appearance at
+
+      '
+    question: List four synonyms for the word beautiful and separate with newline.
+  - answer: 'Five synonyms for Beautiful are
+
+      attractive
+
+      pretty
+
+      gorgeous
+
+      good-looking
+
+      handsome
+
+      '
+    question: List five synonyms for the word beautiful and separate with newline.
+  - answer: 'Five antonyms for Beautiful are
+
+      ugly
+
+      unattractive
+
+      disgusting
+
+      bad
+
+      awful
+
+      '
+    question: List five antonyms for the word attend and separate with newline.
+task_description: to teach a large language model to list the synonyms for a word.


### PR DESCRIPTION
If your PR is related to a contribution to the taxonomy, please, fill
out the following questionnaire. If not, replace this whole text and the
following questionnaire with whatever information is applicable to your PR.


**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- ... List specific number synonyms for one word
- ... List one synonyms for one word
- ...List two synonyms for one word
- ... List three synonyms for one word

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
(instructlab_vv) [root@dell-r640-041 synonyms]#  ilab generate --num-instructions 10
llama_cpp_python is built without hardware acceleration. ilab generate will be very slow.
Generating synthetic data using 'merlinite-7b-lab-Q4_K_M' model, taxonomy:'/home/instructlab/taxonomy' against http://127.0.0.1:8000/v1 server
INFO 2024-05-26 22:36:58,186 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
Q> What is an antonym to the word ‘attend’? Please list and separate with newline.
I> 
A> An antonym to Attend is not attend.

 10%|████████▌                                                                            | 1/10 [00:20<03:05, 20.58s/it]INFO 2024-05-26 22:37:18,766 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:37:38,998 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:37:44,410 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:38:42,586 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:38:55,369 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
Q> Please list and separate with newline some alternative words to describe the word 'attend' that are used when a person is participating in an event or a gathering.
I> 
A> Alternative words to describe 'Attend' are:
Participate in
Take part in
Show up at
Be present at
Join in
Take part in
Contribute to
Make an appearance at
Turn up for
Come to

 30%|█████████████████████████▌                                                           | 3/10 [02:33<06:22,

 50%|██████████████████████████████████████████▌                                          | 

 60%|███████████████████████████████████████████████████                                  
 90%|████████████████████████████████████████████████████████████████████████████▌        | 9/10 [07:32<00:48, 48.13s/it]INFO 2024-05-26 22:44:30,664 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:44:52,830 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:45:40,164 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:45:51,975 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:45:58,184 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:46:21,326 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
INFO 2024-05-26 22:46:46,113 generate_data.py:468 Selected taxonomy path compositional_skills->general->synonyms
```
```
(instructlab_vv) [root@dell-r640-041 synonyms]# ilab train
INFO 2024-05-26 22:48:53,726 config.py:58 PyTorch version 2.3.0 available.
LINUX_TRAIN.PY: NUM EPOCHS IS:  1
LINUX_TRAIN.PY: TRAIN FILE IS:  generated/train_merlinite-7b-lab-Q4_K_M_2024-05-26T22_36_58.jsonl
LINUX_TRAIN.PY: TEST FILE IS:  generated/test_merlinite-7b-lab-Q4_K_M_2024-05-26T22_36_58.jsonl
LINUX_TRAIN.PY: Using device 'cpu'
LINUX_TRAIN.PY: LOADING DATASETS
Generating train split: 11 examples [00:00, 3144.80 examples/s]
Generating train split: 4 examples [00:00, 1685.64 examples/s]
/home/env/instructlabenv/instructlab_vv/lib/python3.12/site-packages/huggingface_hub/file_download.py:1132: FutureWarning: `resume_download` is deprecated and will be removed in version 1.0.0. Downloads always resume when possible. If you want to force a new download, use `force_download=True`.
  warnings.warn(
tokenizer_config.json: 100%|████████████████████████████████████████████████████████| 2.33k/2.33k [00:00<00:00, 23.2MB/s]
tokenizer.model: 100%|████████████████████████████████████████████████████████████████| 493k/493k [00:00<00:00, 9.62MB/s]
tokenizer.json: 100%|███████████████████████████████████████████████████████████████| 1.80M/1.80M [00:00<00:00, 22.8MB/s]
added_tokens.json: 100%|████████████████████████████████████████████████████████████████| 119/119 [00:00<00:00, 1.52MB/s]
special_tokens_map.json: 100%|██████████████████████████████████████████████████████████| 655/655 [00:00<00:00, 7.99MB/s]
Special tokens have been added in the vocabulary, make sure the associated word embeddings are fine-tuned or trained.
LINUX_TRAIN.PY: NOT USING 4-bit quantization
LINUX_TRAIN.PY: LOADING THE BASE MODEL
config.json: 100%|██████████████████████████████████████████████████████████████████████| 644/644 [00:00<00:00, 6.84MB/s]
model.safetensors.index.json: 100%|██████████████████████████████████████████████████| 23.9k/23.9k [00:00<00:00, 161MB/s]
model-00001-of-00003.safetensors: 100%|██████████████████████████████████████████████| 4.94G/4.94G [00:43<00:00, 115MB/s]
model-00002-of-00003.safetensors: 100%|██████████████████████████████████████████████| 5.00G/5.00G [00:43<00:00, 115MB/s]
model-00003-of-00003.safetensors: 100%|██████████████████████████████████████████████| 4.54G/4.54G [00:39<00:00, 115MB/s]
Downloading shards: 100%|██████████████████████████████████████████████████████████████████| 3/3 [02:06<00:00, 42.12s/it]
Loading checkpoint shards: 100%|███████████████████████████████████████████████████████████| 3/3 [00:00<00:00,  6.19it/s]
generation_config.json: 100%|███████████████████████████████████████████████████████████| 136/136 [00:00<00:00, 1.53MB/s]
LINUX_TRAIN.PY: Model device cpu
LINUX_TRAIN.PY: SANITY CHECKING THE BASE MODEL
100%|██████████████████████████████████████████████████████████████████████████████████████| 4/4 [02:40<00:00, 40.04s/it]
LINUX_TRAIN.PY: GETTING THE ATTENTION LAYERS
LINUX_TRAIN.PY: CONFIGURING LoRA
Map: 100%|██████████████████████████████████████████████████████████████████████| 11/11 [00:00<00:00, 1414.65 examples/s]
Map: 100%|████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 1006.37 examples/s]
/home/env/instructlabenv/instructlab_vv/lib/python3.12/site-packages/accelerate/accelerator.py:446: FutureWarning: Passing the following arguments to `Accelerator` is deprecated and will be removed in version 1.0 of Accelerate: dict_keys(['dispatch_batches', 'split_batches', 'even_batches', 'use_seedable_sampler']). Please pass an `accelerate.DataLoaderConfiguration` instead: 
dataloader_config = DataLoaderConfiguration(dispatch_batches=None, split_batches=False, even_batches=True, use_seedable_sampler=True)
  warnings.warn(
LINUX_TRAIN.PY: TRAINING
{'train_runtime': 207.9129, 'train_samples_per_second': 0.053, 'train_steps_per_second': 0.053, 'train_loss': 1.4257791692560369, 'epoch': 1.0}
100%|████████████████████████████████████████████████████████████████████████████████████| 11/11 [03:27<00:00, 18.90s/it]
LINUX_TRAIN.PY: RUNNING INFERENCE ON THE OUTPUT MODEL

===
test 0
===


===
user
===

List a synonym for the word attend.

===
assistant_old
===

Certainly! A synonym for the word "attend" is "participate." Both words have a similar meaning, indicating involvement or engagement in an event or activity. For example, you can "attend" a class or meeting, or you can "participate" in a discussion or workshop.

===
assistant_new
===

Attend: The word attend has several synonyms, including:
    - Be present
    - Show up
    - Be there
    - Participate
    - Be in attendance
    - Be present at
    - Show up for
    - Be a part of
    - Be involved in
    - Join
    - Be there for
    - Be present with
    - Be on hand
    - Be on location
    - Be in the audience
    - Be in the crowd
    - Be in the congregation
    - Be in the gathering
    - Be in the assembly
    - Be in the meeting
    - Be in the session
    - Be in the class
    - Be in the lecture
    - Be in the seminar
    - Be in the workshop
    - Be in the conference
    - Be in the symposium
    - Be in the forum
    - Be in the discussion
    - Be in the debate
    - Be in the interview
    - Be in the talk
    - Be in the speech
    - Be in the presentation
    - Be in the performance
    - Be in the show
    - Be

===
assistant_expected
===

Synonym for Attend is take part in


===
test 1
===


===
user
===

List two synonyms for the word attend and separate with newline.

===
assistant_old
===

attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend
    attend

===
assistant_new
===

Attend\n
Participate\n

===
assistant_expected
===

Two synonyms for Attend are
take part in
be present at


===
test 2
===


===
user
===

List three synonyms for the word attend and separate with newline.

===
assistant_old
===

Attend, attend to, and attend upon are three synonyms for the word attend.

Attend: To be present, to be in attendance.

Attend to: To give attention to, to take care of, to see to.

Attend upon: To wait upon, to serve, to minister to.

These synonyms can be used interchangeably in various contexts to convey the meaning of being present or giving attention to something or someone. For example:

* I will attend the meeting at 3 PM.
* Please attend to the customer's needs.
* I will attend upon the king during his visit.

These examples illustrate how the synonyms can be used in sentences to convey the meaning of being present or giving attention.

===
assistant_new
===

1. attend
    2. attend
    3. attend

===
assistant_expected
===

Three synonyms for Attend are
take part in
be present at
be there at


===
test 3
===


===
user
===

List four synonyms for the word attend and separate with newline.

===
assistant_old
===

1. attend
2. attend
3. attend
4. attend

I'm sorry for the mistake in my previous comment. I understand that you were asking for synonyms for the word "attend." However, I misunderstood your request. Here are four synonyms for "attend":

1. assist
2. accompany
3. participate
4. observe

I apologize for any confusion and hope this information is helpful. If you have any other questions, please let me know!

===
assistant_new
===

1. attend \n
    2. be present \n
    3. be present at \n
    4. be present in \n

===
assistant_expected
===

Four synonyms for Attend are
take part in
be present at
be there at
make an appearance at
Wrote training_results/final/ggml-model-f16.gguf
```

**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
(instructlab_vv) [root@dell-r640-041 synonyms]# ilab chat
╭─────────────────────────────────────────────────────── system ────────────────────────────────────────────────────────╮
│ Welcome to InstructLab Chat w/ MODELS/MERLINITE-7B-LAB-Q4_K_M.GGUF (type /h for help)                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── elapsed 5.047 seconds ─╯
>>> List a synonym for the word attend.                                                                      [S][default]
╭───────────────────────────────────────── models/merlinite-7b-lab-Q4_K_M.gguf ─────────────────────────────────────────╮
│ A synonym for the word "attend" is "show up."                                                                         │
│                                                                                                                       │
│ (continued from previous session)                                                                                     │
╰─────────────────────────────────────────────────────────────────────────────────────────────── elapsed 3.311 seconds ─╯
>>> List two synonyms for the word attend                                                                    [S][default]
╭───────────────────────────────────────── models/merlinite-7b-lab-Q4_K_M.gguf ─────────────────────────────────────────╮
│ Two synonyms for the word "attend" are "present yourself" and "make an appearance."                                   │
│                                                                                                                       │
│ (continued from previous session)                                                                                     │
╰─────────────────────────────────────────────────────────────────────────────────────────────── elapsed 4.259 seconds ─╯
>>> List two synonyms for the word beat                                                                      [S][default]
╭───────────────────────────────────────── models/merlinite-7b-lab-Q4_K_M.gguf ─────────────────────────────────────────╮
│ Two synonyms for the word "beat" are "thump" and "drumbeat."                                                          │
│                                                                                                                       │
│ (continued from previous session)                                                                                     │
╰──────────────────────────────────────────────────```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] The contribution was tested with `ilab generate`
- [ ] No errors or warnings were produced by `ilab generate`
- [ ] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file contains at least 5 `seed_examples`
- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [ ] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [ ] Content does not include PII or otherwise sensitive or confidential information
- [ ] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instructlab/taxonomy/blob/main/docs/SKILLS_GUIDE.md#avoid-these-topics) guidelines
