### PR TITLE
fix yaml indenting of example qna

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,32 +287,32 @@ task_description: 'Teach the model the results of the 2024 Oscars'
 created_by: juliadenham
 domain: pop_culture
 seed_examples:
- - question: When did the 2024 Oscars happen?
-   answer: |
-     The 2024 Oscars were held on March 10, 2024.
- - question: What film had the most Oscar nominations in 2024?
-   answer: |
-     Oppenheimer had 13 Oscar nominations.
- - question: Who presented the 2024 Oscar for Best Original Screenplay and Best Adapted Screenplay?
-   answer: |
-     Octavia Spencer presented the award for Best Original Screenplay and Best Adapted Screenplay at the 2024 Oscars.
- - question: Who hosted the 2024 Oscars?
-   answer: |
-     Jimmy Kimmel hosted the 96th Academy Awards ceremony.
- - question: At the 2024 Oscars, who were the nominees for best director and who won?
-   answer: |
-     The nominees for director at the 2024 Oscars was Christopher Nolan for Oppenheimer,
-     Justine Triet for Anatomy of a Fall, Martin Scorsese for Killers of the Flower Moon,
-     Yorgos Lanthimos for Poor Things, and Jonathan Glazer for The Zone of Interest.
-     Christopher Nolan won best director for Oppenheimer.
- - question: Did Billie Eilish perform at the 2024 Oscars?
-   answer: |
-     Yes Billie Eilish performed "What Was I Made For?" from Barbie at the 2024 Oscars.
+  - question: When did the 2024 Oscars happen?
+    answer: |
+      The 2024 Oscars were held on March 10, 2024.
+  - question: What film had the most Oscar nominations in 2024?
+    answer: |
+      Oppenheimer had 13 Oscar nominations.
+  - question: Who presented the 2024 Oscar for Best Original Screenplay and Best Adapted Screenplay?
+    answer: |
+      Octavia Spencer presented the award for Best Original Screenplay and Best Adapted Screenplay at the 2024 Oscars.
+  - question: Who hosted the 2024 Oscars?
+    answer: |
+      Jimmy Kimmel hosted the 96th Academy Awards ceremony.
+  - question: At the 2024 Oscars, who were the nominees for best director and who won?
+    answer: |
+      The nominees for director at the 2024 Oscars was Christopher Nolan for Oppenheimer,
+      Justine Triet for Anatomy of a Fall, Martin Scorsese for Killers of the Flower Moon,
+      Yorgos Lanthimos for Poor Things, and Jonathan Glazer for The Zone of Interest.
+      Christopher Nolan won best director for Oppenheimer.
+  - question: Did Billie Eilish perform at the 2024 Oscars?
+    answer: |
+      Yes Billie Eilish performed "What Was I Made For?" from Barbie at the 2024 Oscars.
 document:
- repo: https://github.com/juliadenham/oscars2024_knowledge.git
- commit: e1744af
- patterns:
-   - oscars2024_results.md
+  repo: https://github.com/juliadenham/oscars2024_knowledge.git
+  commit: e1744af
+  patterns:
+    - oscars2024_results.md
 ```
 
 *Example `attribution.txt` file*


### PR DESCRIPTION
the example yaml in contributing knowledge has invalid indenting

```
31:4: [warning] wrong indentation: expected 2 but found 3 (indentation
```