### PR TITLE
Add Knowledge about the first female minister in Egypt

### DIFF
--- a/knowledge/history/biography/egypt/hikmat_abu_zayd/attribution.txt
+++ b/knowledge/history/biography/egypt/hikmat_abu_zayd/attribution.txt
@@ -1,0 +1,5 @@
+Title of work: Hikmat Abu Zayd
+Link to work: https://en.wikipedia.org/wiki/Hikmat_Abu_Zayd
+Revision: https://en.wikipedia.org/w/index.php?title=Hikmat_Abu_Zayd&oldid=1214066004
+License of the work: CC-BY-SA-4.0
+Creator names: Wikipedia Authors

--- a/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
+++ b/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
@@ -1,4 +1,5 @@
 created_by: ahmed-azraq
+version: 2
 domain: biography
 seed_examples:
   - answer: |
@@ -6,7 +7,7 @@ seed_examples:
     question: When did Hikmat Abu Zayd die?
   - answer: >
       Hikmat Abu Zayd became the first female cabinet minister in Egypt in
-      1962. 
+      1962.
     question: Who is the first female cabinet minister in Egypt?
   - answer: >
       Born in the village of Shaykh Daud, located near the city of al-Qusiyya in

--- a/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
+++ b/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
@@ -26,6 +26,6 @@ seed_examples:
 task_description: Knowledge contribution about the first female cabinet minister in Egypt
 document:
   repo: https://github.com/ahmed-azraq/instructlab_knowledge.git
-  commit: c8883e384236968cb8da306b0b2198091701e791
+  commit: d189bddec6847b949336d5497e9e19afdc314b6b
   patterns:
     - hikmat-abu-zayd/hikmat.md

--- a/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
+++ b/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
@@ -1,0 +1,31 @@
+---
+created_by: ahmed-azraq
+version: 2
+domain: biography
+seed_examples:
+  - answer: >
+      Hikmat Abu Zayd died on 30 July 2011.
+    question: When did Hikmat Abu Zayd die?
+  - answer: >
+      Hikmat Abu Zayd became the first female cabinet minister in Egypt in 1962. 
+    question: Who is the first female cabinet minister in Egypt?
+  - answer: >
+      Born in the village of Shaykh Daud, located near the city of al-Qusiyya in Asyut Governorate.
+    question: Where was Hikmat Abu Zayd born?
+  - answer: >
+      The country's first two female parliamentarians, Rawya Ateya and Amina Shukri, were elected in 1957.
+    question: Who are Egypt's first two female parliamentarians?
+  - answer: >
+      One of the most sensitive tasks assigned to Abu Zayd was the relocation of thousands of Nubians,
+      displaced by the construction of the Aswan Dam, to newly built villages. Her management of the resettlement
+      process led to her being nicknamed the "Merciful Heart of the Revolution" by Nasser.
+    question: What is the nickname given by Nasser to Hikmat Abu Zayd?
+  - answer: >
+      Abu Zayd received the Lenin Peace Prize in December 1970.
+    question: What award has Hikmat Abu Zayd received?
+task_description: Knowledge contribution about the first female cabinet minister in Egypt
+document:
+  repo: https://github.com/ahmed-azraq/instructlab_knowledge.git
+  commit: c8883e384236968cb8da306b0b2198091701e791
+  patterns:
+    - hikmat-abu-zayd/hikmat.md

--- a/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
+++ b/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
@@ -1,5 +1,4 @@
 created_by: ahmed-azraq
-version: 2
 domain: biography
 seed_examples:
   - answer: |

--- a/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
+++ b/knowledge/history/biography/egypt/hikmat_abu_zayd/qna.yaml
@@ -1,31 +1,34 @@
----
 created_by: ahmed-azraq
 version: 2
 domain: biography
 seed_examples:
-  - answer: >
+  - answer: |
       Hikmat Abu Zayd died on 30 July 2011.
     question: When did Hikmat Abu Zayd die?
   - answer: >
-      Hikmat Abu Zayd became the first female cabinet minister in Egypt in 1962. 
+      Hikmat Abu Zayd became the first female cabinet minister in Egypt in
+      1962. 
     question: Who is the first female cabinet minister in Egypt?
   - answer: >
-      Born in the village of Shaykh Daud, located near the city of al-Qusiyya in Asyut Governorate.
+      Born in the village of Shaykh Daud, located near the city of al-Qusiyya in
+      Asyut Governorate.
     question: Where was Hikmat Abu Zayd born?
   - answer: >
-      The country's first two female parliamentarians, Rawya Ateya and Amina Shukri, were elected in 1957.
+      The country's first two female parliamentarians, Rawya Ateya and Amina
+      Shukri, were elected in 1957.
     question: Who are Egypt's first two female parliamentarians?
   - answer: >
-      One of the most sensitive tasks assigned to Abu Zayd was the relocation of thousands of Nubians,
-      displaced by the construction of the Aswan Dam, to newly built villages. Her management of the resettlement
-      process led to her being nicknamed the "Merciful Heart of the Revolution" by Nasser.
+      One of the most sensitive tasks assigned to Abu Zayd was the relocation of
+      thousands of Nubians, displaced by the construction of the Aswan Dam, to
+      newly built villages. Her management of the resettlement process led to
+      her being nicknamed the "Merciful Heart of the Revolution" by Nasser.
     question: What is the nickname given by Nasser to Hikmat Abu Zayd?
-  - answer: >
+  - answer: |
       Abu Zayd received the Lenin Peace Prize in December 1970.
     question: What award has Hikmat Abu Zayd received?
 task_description: Knowledge contribution about the first female cabinet minister in Egypt
 document:
-  repo: https://github.com/ahmed-azraq/instructlab_knowledge.git
+  repo: 'https://github.com/ahmed-azraq/instructlab_knowledge.git'
   commit: d189bddec6847b949336d5497e9e19afdc314b6b
   patterns:
     - hikmat-abu-zayd/hikmat.md


### PR DESCRIPTION
**Describe the contribution to the taxonomy**

Add knowledge article from Wikipedia about the first female minister in Egypt https://en.wikipedia.org/wiki/Hikmat_Abu_Zayd 


**Input given at the prompt**

Who is the first female minister in Egypt?


**Response from the original model**


The first female minister in Egypt was Samia Hussein, who served as Minister of Planning and International Cooperation from 1981 to 1983 during President Anwar Sadat's regime. She was also the first woman to hold the post of Prime Minister, serving as the acting Prime Minister of Egypt for three days in 1981. Prior to her political career, Samia Hussein was an educator, author, and women's rights activist. 


**Response from the fine-tuned model**


The first female cabinet minister in Egypt was Hikmat Abu Zayd, who served as the Minister of Social Affairs from 1962 to 1965, during the reign of President Gamal Abdel Nasser.


**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [x] The contribution was tested with `ilab generate`
- [x] No errors or warnings were produced by `ilab generate`
- [x] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [x] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [x] Content does not include PII or otherwise sensitive or confidential information
- [x] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instructlab/taxonomy/blob/main/docs/SKILLS_GUIDE.md#avoid-these-topics) guidelines
