### PR TITLE
Inclusive IT terminology

### DIFF
--- a/compositional_skills/grounded/linguistics/inclusion/attribution.txt
+++ b/compositional_skills/grounded/linguistics/inclusion/attribution.txt
@@ -1,0 +1,15 @@
+Title of work: Master-slave(technology)
+Link to work: https://en.wikipedia.org/wiki/Master%E2%80%93slave_(technology)
+License of the work: CC-BY-SA-4.0
+Creator names: Wikipedia Authors
+
+Title of work: Whitelist
+Link to work: https://en.wikipedia.org/wiki/Whitelist
+License of the work: CC-BY-SA-4.0
+Creator names: Wikipedia Authors
+
+
+Title of work: Blacklist (computing)
+Link to work: https://en.wikipedia.org/wiki/Blacklist_(computing)
+License of the work: CC-BY-SA-4.0
+Creator names: Wikipedia Authors

--- a/compositional_skills/grounded/linguistics/inclusion/qna.yaml
+++ b/compositional_skills/grounded/linguistics/inclusion/qna.yaml
@@ -1,0 +1,54 @@
+---
+version: 3
+task_description: This skill helps the writer use more inclusive IT terminology.
+created_by: imstilllearning
+seed_examples:
+  - context: >
+      In database replication, the master database is regarded as the
+      authoritative source, and the slave databases are synchronized to it.
+    question: How would you rewrite this sentence to use more inclusive IT terminology?
+    answer: >
+      In database replication, the primary database is regarded as the
+      authoritative source, and the secondary databases are syncrhonized to it.
+  - context: >
+      Blacklisting is the action of a group or authority compiling a
+      blacklist of people, countries, or other entites to be avoided or
+      distrusted as being deemed unacceptable to those making the list.
+    question: Show me how to use inclusive IT terminology to replace non-inclusive
+      IT terminology.
+    answer: >
+      Denylisting is the action of a group or authority compiling a denylist
+      of people, countries, or other entites to be avoided or distrusted as
+      being deemed unacceptable to those making the list.
+  - context: >
+      In database replication, the master database is regarded as the
+      authoritative source, and the slave databases are synchronized to it.
+    question: How would you revise this sentence to use Inclusive IT terminology?
+    answer: >
+      In database replication, the parent database is regarded as the
+      authoritative source, and the child databases are synchronized to it.
+  - context: >
+      A use for whitelists is in local area network (LAN) security. Many
+      network admins set up MAC address whitelists, or a MAC address filter, to
+      control who is allowed on their networks.
+    question: How would you revise this sentence to use inclusive IT terminology?
+    answer: >
+      A use for allowlists is in local area network (LAN) security. Many
+      network admins set up MAC address allowlists, or a MAC address filter, to
+      control who is allowed on their networks.
+  - context: >
+      A master clock that provides time signals used to synchronize one or
+      more slave clocks as a part of a clock network.
+    question: How would you improve this sentence to use inclusive IT language?
+    answer: >
+      A primary clock that provides time signals used to synchronize one or
+      more secondary clocks as a part of a clock network.
+  - context: >
+      As a verb, blacklist can mean to put an individual or entity on such a
+      list. A blacklist is synonymous with a list of banned persons or
+      organizations and is the opposite of a whitelist.
+    question: How would you adjust the word choice to use Inclusive IT terminology?
+    answer: >
+      As a verb, denylist can mean to put an individual or entity on such a
+      list. A denylist is synonymous with a list of banned persons or
+      organizations and is the opposite of an allowlist.


### PR DESCRIPTION
**Made in collaboration with [shucshar](https://github.com/shucshar)**
Methodology: [Generative Design](https://www.researchgate.net/publication/242386653_Generative_Tools_for_Co-designing)

**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

What: A skill to flag non inclusive IT terminology usage and suggest inclusive IT terminology replacements.

Why: According to [McLean and Company’s HR Trends Report 2023](https://hr.mcleanco.com/research/ss/hr-trends-report-2023?initiate_downloads=false), DEI professionals report that the top challenge was lacking dedicated time to do dedicated DEI work (n=224 organizations reporting in, 59% indicated dedicated time was biggest challenge.)

84% of the reporting sample organizations indicate fostering a culture of belonging is one of the primary areas of influence their DEI org supports.  Additionally, 57% of respondents indicate they do not have a dedicated DEI team or staff at all.

Impact
The inclusive IT Language Skill is one example of what a DEI-driven Technology Roadmap could offer to help scale DEI influence while mitigating the risk of team burnout (39% of HR professionals indicate they experienced increased burnout in their roles, n=822).  

Possible areas of measurement:  
Reduce the # of tactical requests related to inclusion IT terminology guidance. 

Usage counts?

Experience goal: Enable end users to learn privately without putting belonging at risk.

**Input given at the prompt**

<!-- What you entered, replace "..." -->

```
How might you replace the words in the following sentence to be more inclusive? 
A Ceph Monitor maintains the master copy of the Red Hat Ceph Storage cluster map
with the current state of the Red Hat Ceph Storage Cluster.
```


**Response from the original model**


<!-- What you received from the original model in response to your input, 
replace "..." -->

```
To make the sentence more inclusive, consider replacing the terms "Ceph Monitor" 
and "Red Hat Ceph Storage Cluster" with more general terms that don't assume a specific gender or gender identity:    

* Replace "Ceph Monitor" with "cluster administrator" or "data storage manager."                                                                                                                         
* Replace "Red Hat Ceph Storage Cluster" with "data storage system" or "storage infrastructure."                                                                                                        

The revised sentence would look like this:   
A cluster administrator maintains the master copy of the data storage system
with the current state of the storage infrastructure.  
```


**Response from the fine-tuned model**


<!-- Generate a synthetic dataset based on your newly added seed data; train the model 
with the synthetic data and now re-test the model's response with the same prompt.
Replace "..." with what you receive with the finetuned model. -->

```
A cluster administrator maintains the primary copy of the data storage system with the current state of the storage infrastructure.  
```

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [X] The contribution was tested with `ilab generate`
- [X] No errors or warnings were produced by `ilab generate`
- [X] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [X] The `qna.yaml` file contains at least 5 `seed_examples`
- [X] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [X] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [X] Content does not include PII or otherwise sensitive or confidential information
- [X] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instructlab/taxonomy/blob/main/docs/SKILLS_GUIDE.md#avoid-these-topics) guidelines
