### PR TITLE
Update stale_bot.yml to exempt e2e-ready label

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -46,4 +46,4 @@ jobs:
             This pull request has been automatically closed due to inactivity.
           days-before-pr-stale: 15
           days-before-pr-close: 31
-          exempt-pr-labels: triage-approved
+          exempt-pr-labels: e2e-ready


### PR DESCRIPTION
The label for ready PRs was changed to e2e-ready. So we need to update the stale bot config to match the new label name.