### PR TITLE
Make Patterns as a list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,7 +477,8 @@ document_outline: |
 document:
     repo: https://github.com/juliadenham/Summit_knowledge
     commit: 0a1f2672b9b90582e6115333e3ed62fd628f1c0f
-    patterns: phoenix_constellation.md
+    patterns:
+      - phoenix_constellation.md
 ```
 
 *Example `attribution.txt` file*


### PR DESCRIPTION
`document.patterns` need to be a list in `qna.yaml`, updated the README file to reflect that.