### PR TITLE
stalebot: Update exempt label name

### DIFF
--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -46,4 +46,4 @@ jobs:
             This pull request has been automatically closed due to inactivity.
           days-before-pr-stale: 15
           days-before-pr-close: 31
-          exempt-pr-labels: e2e-ready
+          exempt-pr-labels: community-build-ready


### PR DESCRIPTION
The label was renamed to community-build-ready.

