### PR TITLE
Fix 'too many blank lines' error in phoenix/qna.yaml by removing extra blank lines

### DIFF
--- a/knowledge/science/astronomy/constellations/phoenix/qna.yaml
+++ b/knowledge/science/astronomy/constellations/phoenix/qna.yaml
@@ -196,4 +196,3 @@ document:
   commit: 0a1f2672b9b90582e6115333e3ed62fd628f1c0f
   patterns:
     - phoenix_constellation.md
-


### PR DESCRIPTION
Noticed the following error when  running `instructlab.sdg.generate_data()` with the `cmb-run-2024-08-26` branch: `ERROR]: data/taxonomy/knowledge/science/astronomy/constellations/phoenix/qna.yaml:199:1 too many blank lines (1 > 0) (empty-lines)`

This PR removes the extra line from the end of the `data/taxonomy/knowledge/science/astronomy/constellations/phoenix/qna.yaml` to adderess the error. 