### PR TITLE
This   skill helps the writer use more inclusive terminology to avoid ableist bias.

### DIFF
--- a/compositional_skills/grounded/linguistics/inclusion/ableism/attribution.txt
+++ b/compositional_skills/grounded/linguistics/inclusion/ableism/attribution.txt
@@ -1,0 +1,4 @@
+Title of work: Inclusive language
+    License of the work: CC-BY-SA-4.0
+    Creator names: Wikipedia Authors
+    

--- a/compositional_skills/grounded/linguistics/inclusion/ableism/qna.yaml
+++ b/compositional_skills/grounded/linguistics/inclusion/ableism/qna.yaml
@@ -1,0 +1,81 @@
+---
+created_by: julian-cable
+version: 3
+task_description: You are a member of a team with a mission to create the
+  conditions for belonging and inclusion in the workplace. The people whom you
+  support are new to principles of inclusion and need a safe place to fail. This
+  skill helps the writer use more inclusive terminology to avoid ableist bias.
+seed_examples:
+  - context: It is important to consider the blind spots that your organization
+      might have.
+    question: How would you improve this sentence to use more inclusive terminology
+      to avoid any offence to blind people?
+    answer: >-
+      It is important to consider the areas of weakness that your organization
+      might have.
+
+      Avoid "blind spot" in metaphorical use because of possible offence to blind people.
+      Alternatives might be "unseen issue", "unknown obstacle", "something that gets
+      ignored", or "area of weakness".
+  - context: You could be forgiven for thinking it crazy that Microsoft SQL Server
+      runs on Linux.
+    question: How would you improve this sentence to use more inclusive terminology
+      to avoid any offence to people with a mental health condition?
+    answer: >-
+      You could be forgiven for thinking it surprising that Microsoft SQL
+      Server runs on Linux.
+
+      To avoid association with mental health conditions, use an alternative such as
+      "surprising" or "unpredictable".
+  - context: The software is crippleware, and some features of the program such as
+      printing or the ability to save files are unavailable until the user
+      purchases a registration key.
+    question: How would you improve this sentence to use more inclusive terminology
+      to avoid any offence to people with disabilities?
+    answer: >-
+      The software has restricted functions, and some features of the program
+      such as printing or the ability to save files are unavailable until the
+      user purchases a registration key.
+
+      Avoid using "cripple", "crippled", or "crippleware" in a computing context.
+      These terms are pejorative for people with physical disabilities.
+  - context: Avoid a tendency of decision paralysis when deciding on a solution.
+    question: How would you adjust this sentence to use more inclusive terminology
+      to avoid any offence to people with disabilities?
+    answer: >-
+      Avoid a tendency of overanalyzing or overthinking when deciding on a
+      solution.
+
+      To avoid association with physical disabilities, use other wording to refer
+      to taking too long to decide on a solution, such as "overanalyzing", "overthinking",
+      or "indecision".
+  - context: Get the product at an insanely low price!
+    question: How would you adjust this sentence to use more inclusive terminology
+      to avoid any offence to people with a mental health condition?
+    answer: >-
+      Get the product at an unusually low price!
+
+      To avoid association with mental health conditions, use other wording to refer to
+      either someone or something that is considered to be unique, passionate, or extreme,
+      in a positive sense; or conversely in a negative sense to refer to an attempt to
+      discredit or criticize particular ideas, beliefs, principles, or attitudes.
+  - context: Run a sanity check on the software.
+    question: How would you rewrite this sentence to use more inclusive terminology
+      to avoid any offence to neurodiverse people?
+    answer: >-
+      Validate the software.
+
+      Avoid "sanity check" or "sanity test", because those terms might be derogatory
+      to neurodiverse people, and are difficult to translate. Explain exactly what
+      you mean. Consider alternatives such as using "check" alone, or "validate",
+      "verify", "quick check", "coherence check", or "confidence check".
+  - context: Run a sanity test on the software.
+    question: How would you improve this sentence to use more inclusive terminology
+      to avoid any offence to neurodiverse people?
+    answer: >-
+      Test the software.
+
+      Avoid "sanity test" or "sanity check", because those terms might be derogatory
+      to neurodiverse people, and are difficult to translate. Explain exactly what
+      you mean. Consider alternatives such as using "test" alone, or "validate",
+      "verify", "quick check", "coherence check", or "confidence check".

--- a/compositional_skills/grounded/linguistics/inclusion/ableism/qna.yaml
+++ b/compositional_skills/grounded/linguistics/inclusion/ableism/qna.yaml
@@ -8,7 +8,7 @@ task_description: You are a member of a team with a mission to create the
 seed_examples:
   - context: It is important to consider the blind spots that your organization
       might have.
-    question: How would you improve this sentence to use more inclusive terminology
+    question: How might you improve this sentence to use more inclusive terminology
       to avoid any offence to blind people?
     answer: >-
       It is important to consider the areas of weakness that your organization
@@ -19,7 +19,7 @@ seed_examples:
       ignored", or "area of weakness".
   - context: You could be forgiven for thinking it crazy that Microsoft SQL Server
       runs on Linux.
-    question: How would you improve this sentence to use more inclusive terminology
+    question: How might you improve this sentence to use more inclusive terminology
       to avoid any offence to people with a mental health condition?
     answer: >-
       You could be forgiven for thinking it surprising that Microsoft SQL
@@ -30,7 +30,7 @@ seed_examples:
   - context: The software is crippleware, and some features of the program such as
       printing or the ability to save files are unavailable until the user
       purchases a registration key.
-    question: How would you improve this sentence to use more inclusive terminology
+    question: How might you improve this sentence to use more inclusive terminology
       to avoid any offence to people with disabilities?
     answer: >-
       The software has restricted functions, and some features of the program
@@ -40,7 +40,7 @@ seed_examples:
       Avoid using "cripple", "crippled", or "crippleware" in a computing context.
       These terms are pejorative for people with physical disabilities.
   - context: Avoid a tendency of decision paralysis when deciding on a solution.
-    question: How would you adjust this sentence to use more inclusive terminology
+    question: How might you adjust this sentence to use more inclusive terminology
       to avoid any offence to people with disabilities?
     answer: >-
       Avoid a tendency of overanalyzing or overthinking when deciding on a
@@ -50,7 +50,7 @@ seed_examples:
       to taking too long to decide on a solution, such as "overanalyzing", "overthinking",
       or "indecision".
   - context: Get the product at an insanely low price!
-    question: How would you adjust this sentence to use more inclusive terminology
+    question: How might you adjust this sentence to use more inclusive terminology
       to avoid any offence to people with a mental health condition?
     answer: >-
       Get the product at an unusually low price!
@@ -60,7 +60,7 @@ seed_examples:
       in a positive sense; or conversely in a negative sense to refer to an attempt to
       discredit or criticize particular ideas, beliefs, principles, or attitudes.
   - context: Run a sanity check on the software.
-    question: How would you rewrite this sentence to use more inclusive terminology
+    question: How might you rewrite this sentence to use more inclusive terminology
       to avoid any offence to neurodiverse people?
     answer: >-
       Validate the software.
@@ -70,7 +70,7 @@ seed_examples:
       you mean. Consider alternatives such as using "check" alone, or "validate",
       "verify", "quick check", "coherence check", or "confidence check".
   - context: Run a sanity test on the software.
-    question: How would you improve this sentence to use more inclusive terminology
+    question: How might you improve this sentence to use more inclusive terminology
       to avoid any offence to neurodiverse people?
     answer: >-
       Test the software.


### PR DESCRIPTION
Made in collaboration with [shucshar](https://github.com/shucshar) and [nicholasjayantylearns](https://github.com/nicholasjayantylearns)

What: A skill to help writers in different business contexts use more conscious language, to avoid excluding or offending others, even if unintentionally. This skill is broken down by taxonomy, with each taxonomy focusing on avoiding different types of bias in terminology usage.

Why: This initiative is part of a commitment by Red Hat and others to promoting a culture that is intentional, inclusive, and respectful in language, to foster a welcoming and diverse open source community.

**Contribution checklist**

<!-- Insert an x between the empty brackets: [ ] >> [x] 

- [ ] The contribution was tested with `ilab generate`
- [ ] No errors or warnings were produced by `ilab generate` -->
- [x] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [x] The `qna.yaml` file contains at least 5 `seed_examples`
- [x] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [x] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [x] Content does not include PII or otherwise sensitive or confidential information
- [x] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instructlab/taxonomy/blob/main/docs/SKILLS_GUIDE.md#avoid-these-topics) guidelines
