### PR TITLE
Fix typo in compositional_skills/linguistics/synonyms/qna.yaml

### DIFF
--- a/compositional_skills/linguistics/synonyms/qna.yaml
+++ b/compositional_skills/linguistics/synonyms/qna.yaml
@@ -34,7 +34,7 @@ seed_examples:
       make an appearance at
 
       '
-    question: List four synonyms for the word beautiful and separate with newline.
+    question: List four synonyms for the word attend and separate with newline.
   - answer: 'Five synonyms for Beautiful are
 
       attractive


### PR DESCRIPTION
Looks like a typo, the one question didn't match the answer.

**Describe the contribution to the taxonomy**

<!-- A concise description of what the contribution brings, replace "..." in the bullet list -->

- Fix for mismatch between question and answer.


**Input given at the prompt**

**Contribution checklist**

When asking the model about synonyms, I didn't notice any wrong answer. Maybe this specific q'n'a was eliminated during training?

<!-- Insert an x between the empty brackets: [ ] >> [x] -->

- [ ] The contribution was tested with `ilab generate`
- [ ] No errors or warnings were produced by `ilab generate`
- [x] All [commits are signed off](https://github.com/instructlab/taxonomy/blob/main/CONTRIBUTING.md#legal) (DCO)
- [ ] The `qna.yaml` file contains at least 5 `seed_examples`
- [ ] The `qna.yaml` file was [linted](https://yamllint.com) and [prettified](https://onlineyamltools.com/prettify-yaml) ([yaml-validator](https://jsonformatter.org/yaml-validator) can do both)
- [ ] An `attribution.txt` file in the same folder as the `qna.yaml` file
- [x] Content does not include PII or otherwise sensitive or confidential information
- [x] Content does not include anything documented in the project's [Avoid these Topics](https://github.com/instructlab/taxonomy/blob/main/docs/SKILLS_GUIDE.md#avoid-these-topics) guidelines
