### PR TITLE
Add support copilot skills

### DIFF
--- a/compositional_skills/grounded/support_copilot/pam_inquiry/qna.yaml
+++ b/compositional_skills/grounded/support_copilot/pam_inquiry/qna.yaml
@@ -1,0 +1,54 @@
+version: 2
+task_description: "Find the Partner Account Manager (PAM) assigned to a support ticket."
+created_by: mivankovich-redhat
+seed_examples:
+  - context: |
+      A user is asking who the Partner Account Manager is for a support ticket.
+    question: Who is the PAM for SP-0001-REQ?
+    answer: |
+      {"action": "lookup_pam", "ticket": "SP-0001-REQ"}
+  - context: |
+      A user is trying to find the Partner Account Manager linked to a ticket.
+    question: Can you check who the PAM is for sp-9999-req?
+    answer: |
+      {"action": "lookup_pam", "ticket": "sp-9999-req"}
+  - context: |
+      A request for the PAM assigned to a known support ticket.
+    question: Tell me the PAM assigned to SP-8765-REQ
+    answer: |
+      {"action": "lookup_pam", "ticket": "SP-8765-REQ"}
+  - context: |
+      The user wants to know who owns a specific support ticket as the PAM.
+    question: Who owns SP-2000-REQ as PAM?
+    answer: |
+      {"action": "lookup_pam", "ticket": "SP-2000-REQ"}
+  - context: |
+      Asking for the Partner Account Manager responsible for a support case.
+    question: I need the Partner Account Manager for sp-1122-req
+    answer: |
+      {"action": "lookup_pam", "ticket": "sp-1122-req"}
+  - context: |
+      Request to identify the PAM responsible for a specific ticket.
+    question: Get me the PAM for SP-4040-REQ
+    answer: |
+      {"action": "lookup_pam", "ticket": "SP-4040-REQ"}
+  - context: |
+      Determining PAM assignment for a support issue.
+    question: Assigned PAM for ticket Sp-5050-Req?
+    answer: |
+      {"action": "lookup_pam", "ticket": "Sp-5050-Req"}
+  - context: |
+      The user needs to find the PAM associated with a ticket.
+    question: Can you tell me the Partner Account Manager for SP-0707-REQ?
+    answer: |
+      {"action": "lookup_pam", "ticket": "SP-0707-REQ"}
+  - context: |
+      A user is asking which Partner Account Manager is handling a case.
+    question: Who’s the Partner Account Manager tied to Sp-3003-Req?
+    answer: |
+      {"action": "lookup_pam", "ticket": "Sp-3003-Req"}
+  - context: |
+      A user is inquiring about ticket ownership by PAM.
+    question: What PAM is linked to sp-6060-req?
+    answer: |
+      {"action": "lookup_pam", "ticket": "sp-6060-req"}

--- a/compositional_skills/grounded/support_copilot/pam_inquiry/qna.yaml
+++ b/compositional_skills/grounded/support_copilot/pam_inquiry/qna.yaml
@@ -1,5 +1,6 @@
+---
 version: 2
-task_description: "Find the Partner Account Manager (PAM) assigned to a support ticket."
+task_description: "Find the Partner Account Manager (PAM) assigned to a ticket."
 created_by: mivankovich-redhat
 seed_examples:
   - context: |

--- a/compositional_skills/grounded/support_copilot/pam_inquiry/task.py
+++ b/compositional_skills/grounded/support_copilot/pam_inquiry/task.py
@@ -1,0 +1,14 @@
+def convert_to_sample(qna):
+    """
+    Custom converter that preserves JSON answers and concatenates context and question into the prompt.
+    """
+    prompt = ""
+    if "context" in qna:
+        prompt += qna["context"].strip() + "\n"
+    prompt += qna["question"].strip()
+
+    return {
+        "text_prompt": prompt,
+        "text_completion": qna["answer"].strip()
+    }
+

--- a/compositional_skills/grounded/support_copilot/sa_inquiry/qna.yaml
+++ b/compositional_skills/grounded/support_copilot/sa_inquiry/qna.yaml
@@ -1,0 +1,54 @@
+version: 2
+task_description: "Find the Solutions Architect (SA) assigned to a support ticket from the Eco Pool."
+created_by: mivankovich-redhat
+seed_examples:
+  - context: |
+      A user is asking who the Solutions Architect is for a support ticket.
+    question: Who is the SA for SP-0425-REQ?
+    answer: |
+      {"action": "lookup_sa", "ticket": "SP-0425-REQ"}
+  - context: |
+      A user wants to identify the SA working on a specific ticket.
+    question: Find out who owns SP-4444-REQ from the SA team
+    answer: |
+      {"action": "lookup_sa", "ticket": "SP-4444-REQ"}
+  - context: |
+      Question about the Eco Pool SA assigned to a ticket.
+    question: Which Eco Pool SA is assigned to sp-9999-req?
+    answer: |
+      {"action": "lookup_sa", "ticket": "sp-9999-req"}
+  - context: |
+      Determining the Solutions Architect on a particular support request.
+    question: SA assigned to SP-1011-REQ?
+    answer: |
+      {"action": "lookup_sa", "ticket": "SP-1011-REQ"}
+  - context: |
+      Inquiring about the SA on record for a ticket.
+    question: Check the Eco Pool SA on Sp-8888-Req
+    answer: |
+      {"action": "lookup_sa", "ticket": "Sp-8888-Req"}
+  - context: |
+      Who is responsible from the SA team for this ticket?
+    question: Tell me which SA is responsible for SP-3333-REQ
+    answer: |
+      {"action": "lookup_sa", "ticket": "SP-3333-REQ"}
+  - context: |
+      A user is asking to look up the Solutions Architect for a case.
+    question: Solutions Architect assigned to ticket sp-5555-req?
+    answer: |
+      {"action": "lookup_sa", "ticket": "sp-5555-req"}
+  - context: |
+      Request to identify the assigned SA.
+    question: Get me the SA for SP-6060-REQ
+    answer: |
+      {"action": "lookup_sa", "ticket": "SP-6060-REQ"}
+  - context: |
+      Eco Pool SA ownership inquiry.
+    question: Who is the solutions architect tied to Sp-1999-Req?
+    answer: |
+      {"action": "lookup_sa", "ticket": "Sp-1999-Req"}
+  - context: |
+      The user wants to confirm who owns the ticket from the SA team.
+    question: Check who owns SP-2121-REQ on the SA side
+    answer: |
+      {"action": "lookup_sa", "ticket": "SP-2121-REQ"}

--- a/compositional_skills/grounded/support_copilot/sa_inquiry/qna.yaml
+++ b/compositional_skills/grounded/support_copilot/sa_inquiry/qna.yaml
@@ -1,5 +1,6 @@
+---
 version: 2
-task_description: "Find the Solutions Architect (SA) assigned to a support ticket from the Eco Pool."
+task_description: "Find the Solutions Architect (SA) assigned to a ticket."
 created_by: mivankovich-redhat
 seed_examples:
   - context: |

--- a/compositional_skills/grounded/support_copilot/sa_inquiry/task.py
+++ b/compositional_skills/grounded/support_copilot/sa_inquiry/task.py
@@ -1,0 +1,14 @@
+def convert_to_sample(qna):
+    """
+    Custom converter that preserves JSON answers and concatenates context and question into the prompt.
+    """
+    prompt = ""
+    if "context" in qna:
+        prompt += qna["context"].strip() + "\n"
+    prompt += qna["question"].strip()
+
+    return {
+        "text_prompt": prompt,
+        "text_completion": qna["answer"].strip()
+    }
+


### PR DESCRIPTION
Describe the contribution to the taxonomy
- Adds `pam_inquiry` and `sa_inquiry` grounded skill nodes
- Introduces custom `task.py` logic to support structured JSON output
- Enables fine-tuning with agentic prompt/completion structure

Input given at the prompt
{"action": "get_ticket", "ticket_id": "SP-0001-REQ"}

Response from the original model
The Partner Account Manager is Mark Ivankovich.

Response from the fine-tuned model
{"action": "lookup_pam", "ticket": "SP-0001-REQ"}
